### PR TITLE
Feature/ob 279 prod env pipelines

### DIFF
--- a/pre-prod-azure-pipelines.yml
+++ b/pre-prod-azure-pipelines.yml
@@ -1,0 +1,62 @@
+# Build Docker image for this app using Azure Pipelines
+# http://docs.microsoft.com/azure/devops/pipelines/languages/docker?view=vsts
+trigger:
+- release/*
+
+pr: none
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+variables:
+  imageName: 'discover-uni:$(Build.BuildId)'
+  dockerId: preproddiscoverunicontainerregistry
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: 3.7
+    architecture: 'x64'
+
+- task: PythonScript@0
+  displayName: 'Export project path'
+  inputs:
+    scriptSource: 'inline'
+    script: |
+      """Search all subdirectories for `CMS` module."""
+      from glob import iglob
+      from os import path
+      # Python >= 3.5
+      cms = next(iglob(path.join('**', 'CMS'), recursive=True), None)
+      if not cms:
+          raise SystemExit('Could not find the Django project')
+      project_location = path.dirname(path.abspath(cms))
+      print('Found Django project in', project_location)
+      print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
+
+- script: |
+    python -m pip install --upgrade pip setuptools wheel django
+    pip install -r $(projectRoot)/requirements.txt
+    pip install unittest-xml-reporting
+  displayName: 'Install prerequisites'
+
+- script: |
+    pushd '$(projectRoot)'
+    python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input
+  condition: succeededOrFailed()
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFiles: "**/TEST-*.xml"
+    testRunTitle: 'Python $(PYTHON_VERSION)'
+
+- script: |
+    pushd '$(projectRoot)'
+    docker build -f ./deploy_files/Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
+    docker login -u $(dockerId) -p $pswd $(dockerId).azurecr.io
+    docker push $(dockerId).azurecr.io/$(imageName)
+  env:
+    pswd: $(dockerPassword)
+  displayName: 'Build and push Docker image to Dev'

--- a/prod-azure-pipelines.yml
+++ b/prod-azure-pipelines.yml
@@ -1,0 +1,62 @@
+# Build Docker image for this app using Azure Pipelines
+# http://docs.microsoft.com/azure/devops/pipelines/languages/docker?view=vsts
+trigger:
+- master
+
+pr: none
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+variables:
+  imageName: 'discover-uni:$(Build.BuildId)'
+  dockerId: proddiscoverunicontainerregistry
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: 3.7
+    architecture: 'x64'
+
+- task: PythonScript@0
+  displayName: 'Export project path'
+  inputs:
+    scriptSource: 'inline'
+    script: |
+      """Search all subdirectories for `CMS` module."""
+      from glob import iglob
+      from os import path
+      # Python >= 3.5
+      cms = next(iglob(path.join('**', 'CMS'), recursive=True), None)
+      if not cms:
+          raise SystemExit('Could not find the Django project')
+      project_location = path.dirname(path.abspath(cms))
+      print('Found Django project in', project_location)
+      print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
+
+- script: |
+    python -m pip install --upgrade pip setuptools wheel django
+    pip install -r $(projectRoot)/requirements.txt
+    pip install unittest-xml-reporting
+  displayName: 'Install prerequisites'
+
+- script: |
+    pushd '$(projectRoot)'
+    python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input
+  condition: succeededOrFailed()
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFiles: "**/TEST-*.xml"
+    testRunTitle: 'Python $(PYTHON_VERSION)'
+
+- script: |
+    pushd '$(projectRoot)'
+    docker build -f ./deploy_files/Dockerfile -t $(dockerId).azurecr.io/$(imageName) .
+    docker login -u $(dockerId) -p $pswd $(dockerId).azurecr.io
+    docker push $(dockerId).azurecr.io/$(imageName)
+  env:
+    pswd: $(dockerPassword)
+  displayName: 'Build and push Docker image to Dev'


### PR DESCRIPTION
### What

Added CI pipeline definitions for the pre prod and prod environments.
Also done outside of the repo:
- container registry set up for pre prod and prod
- app server for pre prod and prod (currently using dev env variables to test)
- CD release pipeline for pre prod and prod

Prod CD pipeline has a pre deployment check, which requires one of the three of us to approve the deployment before it will go ahead. This is to prevent accidental deployments to prod. When this is triggered we'll get an email with a link to approve it.

### How to review

Running environments can be checked here (https://prod-discover-uni.azurewebsites.net, https://pre-prod-discover-uni.azurewebsites.net).
