### PR TITLE
Refactor/ob 304 remove town city page

### DIFF
--- a/CMS/test/factories.py
+++ b/CMS/test/factories.py
@@ -2,7 +2,7 @@ from wagtail.core.models import Site
 
 from coursefinder.models import CourseFinderResults, CourseFinderLandingPage, CourseFinderChooseCountry, \
     CourseFinderModeOfStudy, CourseFinderChooseSubject, CourseFinderNarrowSearch, CourseFinderPostcode, \
-    CourseFinderSummary, CourseFinderTownCity, CourseFinderUni
+    CourseFinderSummary, CourseFinderUni
 from home.models import HomePage
 
 
@@ -86,19 +86,6 @@ class PageFactory:
         narrow_search_page.save()
 
         return narrow_search_page
-
-    @classmethod
-    def create_town_city_page(cls, title='Test page', path="11111111", depth=1, parent_page=None):
-        if not parent_page:
-            parent_page = cls.create_course_finder_landing_page('Course Finder')
-        town_city_page = CourseFinderTownCity(title=title, path=path, depth=depth)
-
-        parent_page.add_child(instance=town_city_page)
-
-        town_city_page.save_revision().publish()
-        town_city_page.save()
-
-        return town_city_page
 
     @classmethod
     def create_uni_page(cls, title='Test page', path="11111111", depth=1, parent_page=None):

--- a/coursefinder/models.py
+++ b/coursefinder/models.py
@@ -105,24 +105,6 @@ class CourseFinderNarrowSearch(DiscoverUniBasePage):
         return choose_subject_sibling_finder(self)
 
 
-class CourseFinderTownCity(DiscoverUniBasePage):
-    page_order = 5
-    use_skip_form = True
-    question = TextField(blank=True)
-
-    content_panels = Page.content_panels + [
-        FieldPanel('question', classname="full")
-    ]
-
-    @property
-    def next_page(self):
-        return summary_sibling_finder(self)
-
-    @property
-    def back_page(self):
-        return narrow_search_sibling_finder(self)
-
-
 class CourseFinderUni(DiscoverUniBasePage):
     page_order = 6
     use_skip_form = True

--- a/coursefinder/templates/coursefinder/course_finder_narrow_search.html
+++ b/coursefinder/templates/coursefinder/course_finder_narrow_search.html
@@ -17,12 +17,6 @@
         </div>
 
         <div class="radio">
-            <input id="city" type="radio" name="radioGroup" value="city">
-
-            <label for="city">{% get_translation key='specific_town_city' language=page.get_language %}?</label>
-        </div>
-
-        <div class="radio">
             <input id="home" type="radio" name="radioGroup" value="home">
 
             <label for="home">{% get_translation key='near_your_home' language=page.get_language %}?</label>

--- a/coursefinder/tests.py
+++ b/coursefinder/tests.py
@@ -130,22 +130,6 @@ class CourseFinderModelsTests(UniSimpleTestCase):
         self.assertIsNotNone(narrow_search.back_page)
         self.assertEquals(type(narrow_search.back_page), CourseFinderChooseSubject)
 
-    def test_course_finder_town_city_next_page_returns_summary_sibling(self):
-        town_city = PageFactory.create_town_city_page(title='Town City')
-        PageFactory.create_summary_page(title='Summary', path='11111112',
-                                        parent_page=town_city.get_parent())
-
-        self.assertIsNotNone(town_city.next_page)
-        self.assertEquals(type(town_city.next_page), CourseFinderSummary)
-
-    def test_course_finder_town_city_back_page_returns_narrow_search_sibling(self):
-        town_city = PageFactory.create_town_city_page(title='Town City')
-        PageFactory.create_narrow_search_page(title='Narrow Search', path='11111112',
-                                              parent_page=town_city.get_parent())
-
-        self.assertIsNotNone(town_city.back_page)
-        self.assertEquals(type(town_city.back_page), CourseFinderNarrowSearch)
-
     def test_course_finder_uni_next_page_returns_summary_sibling(self):
         uni = PageFactory.create_uni_page(title='Uni')
         PageFactory.create_summary_page(title='Summary', path='11111112', parent_page=uni.get_parent())

--- a/coursefinder/views.py
+++ b/coursefinder/views.py
@@ -3,8 +3,7 @@ from django.http import HttpResponseRedirect
 
 from CMS.enums import enums
 from core.utils import get_page_for_language
-from coursefinder.models import CourseSearch, CourseFinderSearch, CourseFinderUni, CourseFinderTownCity, \
-    CourseFinderPostcode
+from coursefinder.models import CourseSearch, CourseFinderSearch, CourseFinderUni, CourseFinderPostcode
 from coursefinder.models import CourseFinderResults
 
 
@@ -38,8 +37,6 @@ def narrow_search(request, language=enums.languages.ENGLISH):
     selection = post_body.get('radioGroup', None)
     if selection == "uni":
         page = get_page_for_language(language, CourseFinderUni.objects.all())
-    elif selection == "city":
-        page = get_page_for_language(language, CourseFinderTownCity.objects.all())
     elif selection == "home":
         page = get_page_for_language(language, CourseFinderPostcode.objects.all())
     elif selection == 'all':


### PR DESCRIPTION
### What

Removed the town/city narrow search page as it was no longer wanted.

### How to review

Go to the narrow search page of the course finder and you should not see the option to filter by a specific town or city.
