### PR TITLE
Feature/ob 306 remove comparisson

### DIFF
--- a/CMS/templates/partials/course_result.html
+++ b/CMS/templates/partials/course_result.html
@@ -32,5 +32,5 @@
         {% get_translation key='location' language=page.get_language %}: {{ course.location.english_name }}
     </p>
 
-    <input type="button" name="" value="+ {% get_translation key='compare_course' language=page.get_language %}">
+    <!--<input type="button" name="" value="+ {% get_translation key='compare_course' language=page.get_language %}">-->
 </div>

--- a/courses/templates/courses/course_detail_content.html
+++ b/courses/templates/courses/course_detail_content.html
@@ -10,9 +10,9 @@
                 {{course.display_title}}
             </h1>
 
-            <button class="course-detail__compare-btn">
-                + {% get_translation key='compare_course' language=page.get_language %}
-            </button>
+            <!--<button class="course-detail__compare-btn">-->
+                <!--+ {% get_translation key='compare_course' language=page.get_language %}-->
+            <!--</button>-->
         </div>
 
         <div class="course-detail__institution-info">


### PR DESCRIPTION
### What

Commented out the comparison buttons until the comparison functionality is ready

### How to review

Go to the search results page and the course details page and the '+ compare course' buttons should not be there
