### PR TITLE
Several fixes on course details page

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -235,13 +235,13 @@ class Course:
 
     @property
     def show_leo(self):
-        return self.country.name == 'England'
+        return self.country.name == 'England' and self.leo_stats.unavailable_reason
 
     def display_title(self):
         if self.honours_award_provision == "1":
             honours = self.qualification.label + " "
-            english_title = honours + english
-            welsh_title = honours + welsh
+            english_title = honours + self.english_title
+            welsh_title = honours + self.welsh_title
 
         if self.display_language == enums.languages.ENGLISH:
             return english_title if self.english_title else welsh_title

--- a/courses/models.py
+++ b/courses/models.py
@@ -238,9 +238,14 @@ class Course:
         return self.country.name == 'England'
 
     def display_title(self):
+        if self.honours_award_provision == "1":
+            honours = self.qualification.label + " "
+            english_title = honours + english
+            welsh_title = honours + welsh
+
         if self.display_language == enums.languages.ENGLISH:
-            return self.english_title if self.english_title else self.welsh_title
-        return self.welsh_title if self.welsh_title else self.english_title
+            return english_title if self.english_title else welsh_title
+        return welsh_title if self.welsh_title else english_title
 
     @classmethod
     def find(cls, institution_id, course_id, mode, language):
@@ -407,7 +412,7 @@ class EmploymentStatistics:
 
     @property
     def work_and_or_study(self):
-        return self.in_work_and_study + self.in_work_or_study
+        return self.in_work_or_study
 
 
 class JobTypeStatistics:

--- a/courses/templates/courses/partials/after_the_course_body.html
+++ b/courses/templates/courses/partials/after_the_course_body.html
@@ -71,7 +71,7 @@
                 {{block.value.three_years_earnings_heading}}
             </h2>
 
-            {% if course_details.show_leo %}
+            {% if not course_details.show_leo %}
                 <p class="after-course__figure">
                     £{{ course_details.leo_stats.median }}
                 </p>
@@ -94,7 +94,7 @@
 
         {% if course_details.show_leo %}
             <div class="explanation-text">
-                {% create_list course_details.leo_stats.number_of_students as substitutions %}
+                {% create_list course_details.leo_stats.number_of_graduates as substitutions %}
                 {% insert_values_to_rich_text content=block.value.three_years_earnings_data_source substitutions=substitutions as subbed_text %}
                 {{ subbed_text | richtext }}
             </div>

--- a/courses/templates/courses/partials/after_the_course_body.html
+++ b/courses/templates/courses/partials/after_the_course_body.html
@@ -65,13 +65,14 @@
 
     {% include 'courses/partials/unavailable_disclaimer.html' with reason=course_details.salary_stats.unavailable_reason %}
 
+    
     <div class="after-course__block">
         <div class="after-course__data-point">
             <h2 class="after-course__stats-heading">
                 {{block.value.three_years_earnings_heading}}
             </h2>
 
-            {% if not course_details.show_leo %}
+            {% if course_details.show_leo %}
                 <p class="after-course__figure">
                     £{{ course_details.leo_stats.median }}
                 </p>

--- a/courses/templates/courses/partials/entry_information_body.html
+++ b/courses/templates/courses/partials/entry_information_body.html
@@ -98,7 +98,7 @@
                 {% endfor %}
 
                 <div class="explanation-text">
-                    {% create_list course_details.entry_stats.number_of_students as substitutions %}
+                    {% create_list course_details.tariff_stats.number_of_students as substitutions %}
                     {% insert_values_to_rich_text content=block.value.tariffs_data_source substitutions=substitutions as subbed_text %}
                     {{ subbed_text | richtext }}
                 </div>


### PR DESCRIPTION
### What

These include:
- Fix percentage for working or studying
- Fix 3years after the course to populate the correct number of students
- Fix Course details page -course title to include honours
- Fix number of students in ucas tariff stats
- Do not show earnings after 3years if no stats

### How to review

Check changes results in the above changes