### PR TITLE
Comment out further course details as links are currently empty

### DIFF
--- a/courses/templates/courses/course_detail_content.html
+++ b/courses/templates/courses/course_detail_content.html
@@ -126,6 +126,7 @@
         </div>
     </div>
 
+    <!-- Remove line comment once links exist
     <div class="discover-uni-container">
         <div class="course-detail__further-info-block">
             <a href="/dummy-link" class="course-detail__other-courses-link">
@@ -139,4 +140,5 @@
             </a>
         </div>
     </div>
+    -->
 </div>


### PR DESCRIPTION
### What

Hide empty links

### How to review

Check the links at the bottom of the course details page are gone (only links that work should be visible)
