### PR TITLE
Bug/accreditation links

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -793,8 +793,14 @@ class CourseAccreditation:
         if text:
             self.text_english = fallback_to(text.get('english'), '')
             self.text_welsh = fallback_to(text.get('welsh'), '')
+
         url = data_obj.get('url')
-        self.url_english = fallback_to(url.get('english'), '') if url else ''
+        self.url_english = ''
+        self.url_welsh = ''
+        if url:
+            self.url_english = fallback_to(url.get('english'), '')
+            self.url_welsh = fallback_to(url.get('welsh'), '')
+
         dependent = data_obj.get('dependent_on')
         if dependent:
             self.dependent_on_code = dependent.get('code')
@@ -806,4 +812,9 @@ class CourseAccreditation:
         return self.text_welsh if self.text_welsh else self.text_english
 
     def language_url(self):
-        return self.url_english if self.url_english else self.accreditor_url
+        if self.display_language == enums.languages.ENGLISH:
+            return self.url_english if self.url_english else self.url_welsh
+        return self.url_welsh if self.url_welsh else self.url_english
+
+    def show_dependency(self):
+        return self.dependent_on_code == '1'

--- a/courses/request_handler.py
+++ b/courses/request_handler.py
@@ -9,7 +9,6 @@ def load_course_data(institution_id, course_id, mode):
     if settings.LOCAL:
         return CourseMocks.get_successful_course_load_response()
     else:
-        return CourseMocks.get_successful_course_load_response()
         headers = {
             'Ocp-Apim-Subscription-Key': settings.DATASETAPIKEY
         }

--- a/courses/request_handler.py
+++ b/courses/request_handler.py
@@ -9,6 +9,7 @@ def load_course_data(institution_id, course_id, mode):
     if settings.LOCAL:
         return CourseMocks.get_successful_course_load_response()
     else:
+        return CourseMocks.get_successful_course_load_response()
         headers = {
             'Ocp-Apim-Subscription-Key': settings.DATASETAPIKEY
         }

--- a/courses/templates/courses/partials/professional_accreditation_body.html
+++ b/courses/templates/courses/partials/professional_accreditation_body.html
@@ -9,13 +9,16 @@
         {% for accreditation in course_details.accreditations %}
             <p class="accreditation__body">
                 {{accreditation.display_text}}
+                <a href="{{accreditation.accreditor_url}}">{% get_translation key='find_out_more' language=page.get_language %}</a>
             </p>
 
-            <p class="accreditation__explanation">
-                {{accreditation.dependent_on_label}}
+            {% if accreditation.show_dependency %}
+                <p class="accreditation__explanation">
+                    {{accreditation.dependent_on_label}}
 
-                <a href="{{accreditation.language_url}}">{% get_translation key='find_out_more' language=page.get_language %}</a>
-            </p>
+                    <a href="{{accreditation.language_url}}">{% get_translation key='find_out_more' language=page.get_language %}</a>
+                </p>
+            {% endif %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
### What

Update the accreditation section to show the right links in the right place at the right time.

### How to review

Go to a course page that has accreditation, each accreditation should have a find out more link to the accreditation page and if the course has dependencies it should also have a link to the uni site to explain the dependencies.
