### PR TITLE
Bug/fix narrow search

### DIFF
--- a/coursefinder/views.py
+++ b/coursefinder/views.py
@@ -41,11 +41,12 @@ def narrow_search(request, language=enums.languages.ENGLISH):
     elif selection == "home":
         page = get_page_for_language(language, CourseFinderPostcode.objects.all())
     elif selection == 'all':
+        filters = build_filters(post_body)
         course_finder_search = CourseFinderSearch(post_body.get('subject_query', None),
                                                   institution_query,
-                                                  post_body.get('mode_query', None),
                                                   post_body.get('countries_query', None),
                                                   postcode_query,
+                                                  filters,
                                                   post_body.get('page', 1),
                                                   post_body.get('count', 20))
 

--- a/coursefinder/views.py
+++ b/coursefinder/views.py
@@ -40,7 +40,7 @@ def narrow_search(request, language=enums.languages.ENGLISH):
         page = get_page_for_language(language, CourseFinderUni.objects.all())
     elif selection == "home":
         page = get_page_for_language(language, CourseFinderPostcode.objects.all())
-    elif selection == 'all':
+    else:
         filters = build_filters(post_body)
         course_finder_search = CourseFinderSearch(post_body.get('subject_query', None),
                                                   institution_query,


### PR DESCRIPTION
### What
Fix the 404 and 500 errors on the narrow search page

### How to review
Click on the next button with 'don't narrow' selected and there should be no error.
Click on next with no option selected and there should be no error.
