### PR TITLE
handle tilda in widget urls

### DIFF
--- a/widget/static/js/widget.js
+++ b/widget/static/js/widget.js
@@ -343,7 +343,7 @@ DataWidget.prototype = {
             var dataFor = CONTENT.dataFor[this.language];
             var course = document.createTextNode(dataFor + courseName);
         } else {
-            var courseName = this.courseData.statistics.employment.subject[this.languageKey + '_label'];
+            var courseName = this.courseData.statistics.employment[0].subject[this.languageKey + '_label'];
             var dataFor = CONTENT.dataForAggregated[this.language];
             var at = CONTENT.at[this.language];
             var institution = this.courseData.institution.pub_ukprn_name;

--- a/widget/urls.py
+++ b/widget/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from widget.views import widget_iframe, widget_embed
 
 urlpatterns = [
-    url(r'(?P<uk_prn>[\w\-]+)/(?P<kis_course_id>[\w\-]+)/(?P<orientation>[\w\-]+)/(?P<size>[\w\-]+)/'
+    url(r'(?P<uk_prn>[\w\-]+)/(?P<kis_course_id>[\w\-\~]+)/(?P<orientation>[\w\-]+)/(?P<size>[\w\-]+)/'
         r'(?P<language>[\w\-]+)/(?P<kis_mode>[\w\-]+)/', widget_iframe, name='widget_iframe'),
     url('embed-script', widget_embed, name='widget_embed'),
 ]


### PR DESCRIPTION
### What

handle the ~ character in widget urls

### How to review

Go to <domain name>/widget/10007850/UUUH1-G400~USCM-AFB06/horizontal/small/en-GB/FullTime/

The widget should load correctly.
