### PR TITLE
Bug/widget urls

### DIFF
--- a/CMS/urls.py
+++ b/CMS/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     url(r'^course-details/', include(courses_urls)),
     url(r'^institution-details/', include(institution_urls)),
 
-    url(r'(?P<language>[\w\-]+)/', include(welsh_urls)),
+    url(r'(?P<language>[\w\-]+?)/', include(welsh_urls)),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from courses.views import courses_detail
 
 urlpatterns = [
-    url(r'(?P<institution_id>[\w\-]+)/(?P<course_id>[\w\-\~]+)/(?P<kis_mode>[\w\-]+)/', courses_detail,
+    url(r'(?P<institution_id>[\w\-]+?)/(?P<course_id>[\w\-\~]+?)/(?P<kis_mode>[\w\-]+?)/', courses_detail,
         name='courses_detail'),
 ]

--- a/institutions/urls.py
+++ b/institutions/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from institutions.views import institution_detail
 
 urlpatterns = [
-    url(r'(?P<institution_id>[\w\-]+)/', institution_detail, name='institution_detail'),
+    url(r'(?P<institution_id>[\w\-]+?)/', institution_detail, name='institution_detail'),
 ]

--- a/widget/urls.py
+++ b/widget/urls.py
@@ -4,6 +4,6 @@ from widget.views import widget_iframe, widget_embed
 
 urlpatterns = [
     url(r'(?P<uk_prn>[\w\-]+)/(?P<kis_course_id>[\w\-\~]+)/(?P<orientation>[\w\-]+)/(?P<size>[\w\-]+)/'
-        r'(?P<language>[\w\-]+)/(?P<kis_mode>[\w\-]+)/', widget_iframe, name='widget_iframe'),
-    url('embed-script', widget_embed, name='widget_embed'),
+        r'(?P<language>[\w\-]+)/(?P<kis_mode>[\w\-]+)/$(?i)', widget_iframe, name='widget_iframe'),
+    url(r'^embed-script/$(?i)', widget_embed, name='widget_embed'),
 ]

--- a/widget/urls.py
+++ b/widget/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from widget.views import widget_iframe, widget_embed
 
 urlpatterns = [
-    url(r'(?P<uk_prn>[\w\-]+)/(?P<kis_course_id>[\w\-\~]+)/(?P<orientation>[\w\-]+)/(?P<size>[\w\-]+)/'
-        r'(?P<language>[\w\-]+)/(?P<kis_mode>[\w\-]+)/$(?i)', widget_iframe, name='widget_iframe'),
+    url(r'(?P<uk_prn>[\w\-]+?)/(?P<kis_course_id>[\w\-\~]+?)/(?P<orientation>[\w\-]+?)/(?P<size>[\w\-]+?)/'
+        r'(?P<language>[\w\-]+?)/(?P<kis_mode>[\w\-]+?)/$(?i)', widget_iframe, name='widget_iframe'),
     url(r'^embed-script/$(?i)', widget_embed, name='widget_embed'),
 ]


### PR DESCRIPTION
### What

Made the urls for the widget case insensitive and made trailing slashes optional

### How to review

Try loading the widget with a capitol letter in the word widget, the url should be updated to lowercase and the page should load.

Try loading the course detail page for a course without the slash on the end of the url, the url should be updated to have a trailing slash and the page should load correctly.
