### PR TITLE
Add missing allowed hosts

### DIFF
--- a/CMS/settings/production.py
+++ b/CMS/settings/production.py
@@ -6,8 +6,12 @@ DEBUG = False
 SECRET_KEY = os.environ.get('SECRET_KEY')
 
 ALLOWED_HOSTS = [
-    'discoveruni.gov.uk',
     'pre-prod-discover-uni.azurewebsites.net',
+    'discoveruni.org.uk'
+    'www.discoveruni.org.uk'
+    'production-discover-uni.azurewebsites.net'
+    'discoveruni.gov.uk',
+    'www.discoveruni.gov.uk'
     'prod-discover-uni.azurewebsites.net'
 ]
 


### PR DESCRIPTION
### What

Missing acceptable domain names for sites

### How to review

Check the following have been added:
```
discoveruni.org.uk
www.discoveruni.org.uk
discoveruni.gov.uk
www.discoveruni.gov.uk
```