### PR TITLE
don't show the TEF reason link for institutions that didn't participate

### DIFF
--- a/institutions/templates/institutions/institution_detail_page.html
+++ b/institutions/templates/institutions/institution_detail_page.html
@@ -129,10 +129,12 @@
                     {% endif %}
                 </div>
 
-                <a class="institution-details__tef-report-link"
-                   href="https://www.officeforstudents.org.uk/advice-and-guidance/teaching/tef-outcomes/#/tefoutcomes/provider/{{institution.pub_ukprn}}">
-                    {{page.tef_report_link}}
-                </a>
+                {% if not institution.tef_is_not_participate %}
+                    <a class="institution-details__tef-report-link"
+                       href="https://www.officeforstudents.org.uk/advice-and-guidance/teaching/tef-outcomes/#/tefoutcomes/provider/{{institution.pub_ukprn}}">
+                        {{page.tef_report_link}}
+                    </a>
+                {% endif %}
 
                 <div class="explanation">
                     <div class="explanation__link">


### PR DESCRIPTION
### What

Don't show the TEF reason link for institutions that didn't participate

### How to review

Go to an institution page the link See why <university> was awarded this TEF rating, should be visible unless they didn't participate.

