### PR TITLE
fall back to the key if not in dict

### DIFF
--- a/core/templatetags/discover_uni_tags.py
+++ b/core/templatetags/discover_uni_tags.py
@@ -33,7 +33,7 @@ def queryparams(*_, **kwargs):
 def get_translation(*_, **kwargs):
     key = kwargs.get('key')
     language = kwargs.get('language')
-    string = DICT.get(key).get(language) if key in DICT else ''
+    string = DICT.get(key).get(language) if key in DICT else key
 
     if not string:
         string = DICT.get(key).get(enums.languages.ENGLISH) if key in DICT else ''


### PR DESCRIPTION
### What

If key for translations isn't present in the translations dict, use the key instead.

### How to review

Go to a course page and all the common jobs should have labels.
