### PR TITLE
don't put quotes around the subject codes

### DIFF
--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -656,7 +656,7 @@
                 $(option).attr("disabled", "disabled");
                 if (option.dataset.code.includes(this.subjectSelector[0].value)) {
                     $(option).removeAttr("disabled");
-                    all += '"' + option.value + '",';
+                    all += option.value + ',';
                 }
             }
             this.subjectCodeOptions[0].value = all;


### PR DESCRIPTION
### What

Remove the quotes around the subject codes on search.

### How to review

Go to the coursefinder and pick computing in the first 2 subject dropdowns. You should see results on the results page and only for the computing courses.
