### PR TITLE
fix subject selector for IE11

### DIFF
--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -673,7 +673,7 @@
             for (var i = 0; i < this.subjectOptions.length; i++) {
                 var option = this.subjectOptions[i];
                 $(option).removeAttr("disabled");
-                if (!option.value.includes(this.subjectAreaSelector[0].value)) {
+                if (option.value.indexOf(this.subjectAreaSelector[0].value) === -1) {
                     $(option).attr("disabled", "disabled");
                 }
             }


### PR DESCRIPTION
### What

Make the subject selector IE compatible

### How to review

In IE go to the subject selector page of the course finder.
You should now be able to select a subject.
