### PR TITLE
fix typo

### DIFF
--- a/coursefinder/static/js/narrow-search.js
+++ b/coursefinder/static/js/narrow-search.js
@@ -10,7 +10,7 @@
             this.btn = this.wrapper.find('.course-finder-content__next-button');
             this.form = this.wrapper.find('.course-finder-content__question-form');
             sessionStorage.setItem('uni', '')
-            sessionStorage.getItem('postcode', '')
+            sessionStorage.setItem('postcode', '')
 
             var subject_query = sessionStorage.getItem('subjectCodes');
             var mode_query = sessionStorage.getItem('modes');


### PR DESCRIPTION
### What

Reset the narrow search fields when you land on the narrow search page to prevent reapplying old filters.

### How to review

Read the change (typo)
