### PR TITLE
fix to empty drop-down after back button press

### DIFF
--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -169,7 +169,6 @@
             var uiSelect = document.createElement("div");
             uiSelect.setAttribute("class", "select-selected");
             uiSelect.setAttribute('tabindex', 0)
-            uiSelect.innerHTML = baseSelect.options[baseSelect.selectedIndex].innerHTML;
             this.wrapper.append(uiSelect);
             this.uiSelect = this.wrapper.find('.select-selected');
             this.startWatcher();


### PR DESCRIPTION
### What

Fixed issue of empty/missing drop-downs on course-finder-choose-subject screen when hitting back on the browser to this screen

### How to review

Describe the steps required to test the changes.
