### PR TITLE
fix dropdown width on desktop

### DIFF
--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -216,7 +216,7 @@
 
             &-selector {
                 .select-items {
-                    width: calc(100vw - 60px);
+                    max-width: 1020px;
                 }
             }
         }


### PR DESCRIPTION
### What

Put the correct width CSS in for compare dropdowns on desktop.

### How to review

Go to the comparison page and click on one of the two dropdowns.
The dropdown should stay within the container.
