### PR TITLE
there should be only one get context method

### DIFF
--- a/site_search/models.py
+++ b/site_search/models.py
@@ -29,14 +29,10 @@ class SearchLandingPage(DiscoverUniBasePage):
         context['search_url'] = self.get_search_url()
         context['course_finder_url'] = get_page_for_language(self.get_language(),
                                                              CourseFinderChooseCountry.objects.all()).url
+        context['institutions_list'] = InstitutionList.options
         return context
 
     def get_search_url(self):
         if self.get_language() == enums.languages.WELSH:
             return "/%s/results" % self.get_language()
         return '/results'
-
-    def get_context(self, request):
-        context = super().get_context(request)
-        context['institutions_list'] = InstitutionList.options
-        return context

--- a/site_search/templates/site_search/search_landing_page.html
+++ b/site_search/templates/site_search/search_landing_page.html
@@ -22,7 +22,7 @@
                         {{ page.search_heading }}
                     </p>
 
-                    <form class="search-landing-page__search" action="{{ search_url }}" method="get" autocomplete="off">
+                    <form class="search-landing-page__search" action="{{search_url}}" method="get" autocomplete="off">
                         <div class="search-landing-page__search-fields">
                             <div class="search-landing-page__search-input">
                                 <input name="subject_query" type="text" id="course" placeholder = "{% get_translation key='course_name' language=page.get_language %}" autocomplete="off">
@@ -42,7 +42,7 @@
                     </form>
                 </div>
 
-                <a href='{{ course_finder_url }}' class="search-landing-page__nav-card">
+                <a href='{{course_finder_url}}' class="search-landing-page__nav-card">
                     <p class="search-landing-page__nav-card-label">
                         {{ page.course_finder_heading }}
                     </p>


### PR DESCRIPTION
### What

Remove second get_context method as it was overwriting the first and params were being lost.

### How to review

Go to the search landing page, you should now be able to submit a search term and be taken to the results page.
