### PR TITLE
remove calls to the db in the widget loading

### DIFF
--- a/CMS/settings/base.py
+++ b/CMS/settings/base.py
@@ -21,6 +21,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 LOCAL = os.environ.get('LOCAL', False)
 READ_ONLY = os.environ.get('READ_ONLY', False)
 
+ROOT_DOMAIN = os.environ.get('ROOT_DOMAIN', 'http://localhost:3000')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       AZURE_ACCOUNT_KEY:  "${AZURE_ACCOUNT_KEY}"
       AZURE_CONTAINER:  "${AZURE_CONTAINER}"
       READ_ONLY:  "${READ_ONLY}"
+      ROOT_DOMAIN: "${ROOT_DOMAIN}"
     build: .
     command: bash -c "python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
 #    command: bash -c "sh ./deploy_files/docker-entrypoint.sh"

--- a/widget/views.py
+++ b/widget/views.py
@@ -49,6 +49,6 @@ def widget_embed(request):
     final_script = script.replace('{% styles %}', compressed_css)
     final_script = final_script.replace('{{api_domain}}', settings.WIDGETAPIHOST)
     final_script = final_script.replace('{{api_key}}', settings.WIDGETAPIKEY)
-    final_script = final_script.replace('{{domain_name}}', request.site.root_url)
+    final_script = final_script.replace('{{domain_name}}', settings.ROOT_DOMAIN)
 
     return HttpResponse(final_script, content_type='application/javascript')


### PR DESCRIPTION
### What

Load the domain name from settings rather than db.

### How to review

Read the changes. Try loading the widget, it should load correctly.
