### PR TITLE
Fix for widget ignoring Part Time courses.

### DIFF
--- a/widget/views.py
+++ b/widget/views.py
@@ -17,7 +17,7 @@ def widget_iframe(request, uk_prn, kis_course_id, optional_1=None, optional_2=No
                 orientation = param
             if param.lower() == 'en-gb' or param.lower() == 'cy-gb':
                 language = param
-            if param.lower() == 'FullTime' or param.lower() == 'PartTime':
+            if param.lower() == 'fulltime' or param.lower() == 'parttime':
                 kis_mode = param
     context = {
         'uk_prn': uk_prn,


### PR DESCRIPTION
Fixed issue with kis_mode being always set to default FullTime by making the comparison strings lowercase.
