### PR TITLE
Cookie banner showing even after excepting

### DIFF
--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -121,6 +121,10 @@
         setup: function() {
             this.acceptBtn = this.wrapper.find('.cookie-banner__ok');
             this.findOutMoreBtn = this.wrapper.find('.cookie-banner__find-out-more');
+            if (localStorage.discoverUniCookies === 'accepted') {
+                document.cookie = "discoverUniCookies=accepted;";
+                this.wrapper.hide();
+            }
 
             this.startWatchers();
         },
@@ -130,6 +134,7 @@
 
             this.acceptBtn.click(function() {
                 document.cookie = "discoverUniCookies=accepted;";
+                localStorage.discoverUniCookies = 'accepted';
                 that.wrapper.hide();
             });
         }


### PR DESCRIPTION
### What

Using local storage with the cookies to ensure it sets correctly and doesn't show the banner more than once.

### How to review

Clear cookies.
Load the site.
Accept the cookies.
Go to a new page.
The banner should not show again.
