### PR TITLE
Fix to widget display issue.

### DIFF
--- a/widget/static/js/widget.js
+++ b/widget/static/js/widget.js
@@ -385,7 +385,7 @@ DataWidget.prototype = {
             var courseName = this.courseData.course_name[this.languageKey];
             var dataFor = CONTENT.dataForAggregated[this.language];
             var at = CONTENT.at[this.language];
-            var institution = this.courseData.institution_name;
+            var institution = this.courseData.institution_name[this.languageKey];
             var course = document.createTextNode(dataFor + courseName + at + institution);
         }
         courseNode.appendChild(course);


### PR DESCRIPTION
### OFS-160

Fixed widged displaying [object Object] at the bottom instead of university name.
https://www.discoveruni.gov.uk/Widget/10007783/G120/horizontal/small/en-GB/
https://www.discoveruni.gov.uk/Widget/10007163/U-Q300/horizontal/small/en-GB/

### How to review

Run wagtail on localhost. Check the widged displays university name using the example links:
http://localhost:8000/Widget/10007783/G120/horizontal/small/en-GB/
http://localhost:8000/Widget/10007163/U-Q300/horizontal/small/en-GB/
