### PR TITLE
added Bridgend College fix to institutions_cy.json

### DIFF
--- a/CMS/static/jsonfiles/institutions_cy.json
+++ b/CMS/static/jsonfiles/institutions_cy.json
@@ -1500,9 +1500,9 @@
         "order_by_name": "pearson college london"
     },
     {
-        "alphabet": "b",
-        "name": "Bridgend College",
-        "order_by_name": "bridgend"
+        "alphabet": "p",
+        "name": "Coleg Penybont",
+        "order_by_name": "Penybont"
     },
     {
         "alphabet": "p",


### PR DESCRIPTION
### What

Change "Bridgend College" to "Coleg Penybont" in the `CMS/static/jsonfiles/institutions_cy.json` file

### How to review

Switch to the english version of the site. In the institutions drop-down search for "bridge". "Bridgend College" Should show up in the search results.
Switch to the welsh version of the site. In the institutions drop-down search for "peny". "Coleg Penybont" Should show up in the search results.
*(conduction a full search for "Coleg Penybont" will not work yet as all the courses for Bridgend College still have "Bridgend College" as the welsh name for them. A static entry has been added to `ukrpl_static` but a new ingestion has to be run to pick this up)*
