### PR TITLE
fixed postcode bug

### DIFF
--- a/coursefinder/forms.py
+++ b/coursefinder/forms.py
@@ -12,10 +12,10 @@ class FilterForm:
         self.institutions = form_data.get('institution_query', '').replace('"', '')
         self.courses = form_data.get('subject_query', '')
         self.course_query = form_data.get('course_query', '')
-        postcode_query = form_data.get('postcode_query')
-        if postcode_query:
-            self.postcode = postcode_query.split(',')[0]
-            self.distance = postcode_query.split(',')[1]
+        self.postcode_query = form_data.get('postcode_query', '')
+        if self.postcode_query:
+            self.postcode = self.postcode_query.split(',')[0]
+            self.distance = self.postcode_query.split(',')[1]
         else:
             self.postcode = ''
             self.distance = ''

--- a/coursefinder/templates/coursefinder/partials/filters.html
+++ b/coursefinder/templates/coursefinder/partials/filters.html
@@ -185,7 +185,7 @@
                         </div>
                     </div>
 
-                    <input hidden id="postcode_query" name="postcode_query" type="text" value="" />
+                    <input hidden id="postcode_query" name="postcode_query" type="text" value="{{ filter_form.postcode_query }}" />
                 </div>
 
                     {# qualification type filter not yet supported on the API #}


### PR DESCRIPTION
### What

Added the postcode value as a default to an input on the filters form

### How to review

1. Start a search query using the Course Finder Wizard
2. Select to search by postcode, and use 'WC1H0XG' within 50 miles.
3. The first page of the search results will be filtered correctly. At the bottom of the page, click to change to page 2 or 3.
4. Confirm that the only institutions being shown are in London
