### PR TITLE
fixed margin and also overflow institution location section

### DIFF
--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -46,7 +46,7 @@ a {
 
 @media only screen and (min-width: 770px) {
   .discover-uni-container {
-    max-width: 1020px;
+    max-width: 11490px;
     margin-right: auto;
     margin-left: auto;
   }

--- a/institutions/static/scss/institution_details.scss
+++ b/institutions/static/scss/institution_details.scss
@@ -54,6 +54,10 @@
                 justify-content: center;
                 align-items: center;
 
+                div.item{
+                    overflow:auto;
+                }
+
                 .institution-details__overview-item-heading {
                     
                     @include xs-heading-mixin();


### PR DESCRIPTION
### What

Fixed what appeared to be a greater left margin / off-center institution details page. Also fixed overflow for the institution locations (eg check University of Chester which has a long list of locations). 