### PR TITLE
added fix to removed border issue with the widget

### DIFF
--- a/widget/static/css/widget.css
+++ b/widget/static/css/widget.css
@@ -79,7 +79,10 @@
 
 .kis-widget.vertical {
     width: 186px;
-    height: 496px;
+    /* This has been removed because if one of the pages in the animation is */
+    /* larger than the box it will overflow the box and the border will not */
+    /* apear at the bottom any more */
+    /*height: 496px;*/
     flex-direction: column;
 }
 


### PR DESCRIPTION
### What

Removed the border height constraint in css for the widget

### How to review

1. in your docker-compose.dev.yml change the following value:
```
    WIDGETAPIHOST: "https://prod-discoveruni.azure-api.net/widget"
    WIDGETAPIKEY: "..."
```
_(you can get these from the `docker-compose.yml` in the `widget-server` app)_
2. Visit http://localhost:8000/widget/10007783/N400/vertical/small/en-GB/FullTime/
3. Wait for ONE full rotation of the carousel and see if the bottom off the widget extends and overlaps the outer bottom green boarder. No? Good. The fixed worked 
