### PR TITLE
unavailable messages now do not show when agg is 24 for course page >…

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -1730,6 +1730,7 @@ class GraduatePerceptionStatistics:
             self.go_work_on_track = fallback_to(go_voice_work_data.get('go_work_on_track'), '')
             self.go_work_pop = fallback_to(go_voice_work_data.get('go_work_pop'), '')
             self.go_work_resp_rate = fallback_to(go_voice_work_data.get('go_work_resp_rate'), '')
+            self.go_work_agg = fallback_to(go_voice_work_data.get('go_work_agg'), '')
 
     def display_subject_name(self):
         if self.display_language == enums.languages.ENGLISH:

--- a/courses/templates/courses/partials/employment_after_the_course_body.html
+++ b/courses/templates/courses/partials/employment_after_the_course_body.html
@@ -49,8 +49,9 @@
                                         {% if course_details.has_multiple_employment_stats %}
                                             {{ employment_stats.display_subject_name }}{% endif %}
                             </h2>
-
-                            {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=employment_stats.display_unavailable_info %}
+                            {% if employment_stats.aggregation_level != 24 %}
+                                {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=employment_stats.display_unavailable_info %}
+                            {% endif %}
 
                             <div class="explanation-text">
                                 {% create_list course_details.data_from_html employment_stats.number_of_students employment_stats.response_rate as substitutions %}
@@ -244,7 +245,9 @@
                         </h2>
                         {% if jobtype_stats.number_of_students and joblist_stats.jobs %}
 
-                            {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=jobtype_stats.display_unavailable_info %}
+                            {% if jobtype_stats.aggregation_level != 24 %}
+                                {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=jobtype_stats.display_unavailable_info %}
+                            {% endif %}
 
                             <div class="employment-after-course_explanation-text">
                                 {% create_list course_details.data_from_html jobtype_stats.number_of_students jobtype_stats.response_rate as substitutions %}
@@ -252,9 +255,13 @@
                                 {{ subbed_text | richtext }}
                             </div>
                         {% elif jobtype_stats and jobtype_stats.display_unavailable_info %}
-                            {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=jobtype_stats.display_unavailable_info %}
+                            {% if jobtype_stats.aggregation_level != 24 %}
+                                {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=jobtype_stats.display_unavailable_info %}
+                            {% endif %}
                         {% else %}
-                            {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=course_details.display_no_earnings_info %}
+                            {% if jobtype_stats.aggregation_level != 24 %}
+                                {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=course_details.display_no_earnings_info %}
+                            {% endif %}
                         {% endif %}
 
                     </div>

--- a/courses/templates/courses/partials/graduate_perceptions_body.html
+++ b/courses/templates/courses/partials/graduate_perceptions_body.html
@@ -37,7 +37,6 @@
                     </div>
             </div>
 
-            <!-- {{ perceptions_stats.go_work_agg }} -->
             {% if perceptions_stats.go_work_agg != '24' %}
                 <div class="mt-3">
                     {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=perceptions_stats.display_unavailable_info %}

--- a/courses/templates/courses/partials/graduate_perceptions_body.html
+++ b/courses/templates/courses/partials/graduate_perceptions_body.html
@@ -17,7 +17,7 @@
 <div class="tab-content">
     {% for perceptions_stats in course_details.graduate_perceptions %}
         <div class="tab-pane {% if not forloop.counter0 %} show active  {% endif %}" id="grad-perceptions-{{ forloop.counter }}" role="tabpanel" aria-labelledby="grad-perceptions-{{ forloop.counter }}-tab">
-    
+
         {% if perceptions_stats.go_work_mean %}
             <div class="student-satisfaction__overview mt-3 mx-1 p-3 d-flex flex-wrap row">
                     <div class="col-lg-2 col-md-12 align-self-stretch text-center">
@@ -37,9 +37,12 @@
                     </div>
             </div>
 
-            <div class="mt-3">
-                {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=perceptions_stats.display_unavailable_info %}
-            </div>
+            <!-- {{ perceptions_stats.go_work_agg }} -->
+            {% if perceptions_stats.go_work_agg != '24' %}
+                <div class="mt-3">
+                    {% include 'courses/partials/unavailable_disclaimer.html' with unavailable=perceptions_stats.display_unavailable_info %}
+                </div>
+            {% endif %}
 
             <div class="student-satisfaction__block">
                 <div class="student-satisfaction__data-group d-flex flex-wrap row py-3 mx-1">


### PR DESCRIPTION
… emplayment and graduate perceptions

### What

Added additiona conditional statment in the course page template to only show unavailable messages when the respective agg value is NOT 24

### How to review

1. Look at http://localhost:8000/course-details/10000055/AB36/Full-time/
2. It should have the following messages:

-- Employment 15 months after the course
(Underneath > ) "What graduates are doing 15 months after the course"
"The data displayed ..."  <<<

(Underneath >) Under ocupation types 15 months after the course
"The data displayed ..."   <<<

-- Graduate Perceptions
(Underneath >) [HEADLINE] 80% of graduates find their current work meanful 
"The data displayed ..."   <<<

3. look at http://localhost:8000/course-details/10000291/K00001/Full-time/
4. It should not