### PR TITLE
salary course title now based on either leo3, loe5 or go_salary_inst …

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -301,6 +301,33 @@ class Course:
             if title:
                 self.english_title = fallback_to(title.get('english'), '')
                 self.welsh_title = fallback_to(title.get('welsh'), '')
+
+            self.title_form_salary_data = self.english_title
+            if self.display_language == enums.languages.WELSH:
+                self.title_form_salary_data = self.welsh_title
+
+            go_salary_inst_data = leo3_subject = course_details.get('go_salary_inst')[0]
+            leo3_data = leo3_subject = course_details.get('leo3_inst')[0]
+            leo5_data = leo3_subject = course_details.get('leo5_inst')[0]
+
+            if 'subject' in go_salary_inst_data:
+                go_salary_inst_subject = go_salary_inst_data['subject']
+                self.title_form_salary_data = go_salary_inst_subject['english_label']
+                if self.display_language == enums.languages.WELSH:
+                    self.title_form_salary_data = go_salary_inst_subject['welsh_label']
+
+            if 'subject' in leo3_data:
+                leo3_subject = leo3_data['subject']
+                self.title_form_salary_data = leo3_subject['english_label']
+                if self.display_language == enums.languages.WELSH:
+                    self.title_form_salary_data = leo3_subject['welsh_label']
+
+            if 'subject' in leo5_data:
+                leo5_subject = leo5_data['subject']
+                self.title_form_salary_data = leo5_subject['english_label']
+                if self.display_language == enums.languages.WELSH:
+                    self.title_form_salary_data = leo5_subject['welsh_label']
+
             self.honours_award_provision = course_details.get('honours_award_provision')
 
             institution = course_details.get('institution')
@@ -1800,8 +1827,6 @@ class Salary:
             self.subject_english = subject_data.get('english_label', '')
             self.subject_welsh = subject_data.get('welsh_label', '')
 
-            self.subject_title_in_local_language = self.subject_english
-
             # TODO Why do we need two of those?
             self.unavail_reason = salary_data['unavail_reason']
             self.unavailable_reason = "" #fallback_to(salary_data.get('reason'), '')
@@ -1865,7 +1890,6 @@ class Salary:
                     self.earnings_aggregation_str = salary_data['earnings_agg_unavail_message']['english']
                 else:
                     self.earnings_aggregation_str = salary_data['earnings_agg_unavail_message']['welsh']
-                    self.subject_title_in_local_language = self.subject_welsh
 
                 self.earnings_aggregation_msg["msg_heading"], self.earnings_aggregation_msg["msg_body"] = separate_unavail_reason(self.earnings_aggregation_str)
 

--- a/courses/models.py
+++ b/courses/models.py
@@ -301,33 +301,6 @@ class Course:
             if title:
                 self.english_title = fallback_to(title.get('english'), '')
                 self.welsh_title = fallback_to(title.get('welsh'), '')
-
-            self.title_form_salary_data = self.english_title
-            if self.display_language == enums.languages.WELSH:
-                self.title_form_salary_data = self.welsh_title
-
-            go_salary_inst_data = leo3_subject = course_details.get('go_salary_inst')[0]
-            leo3_data = leo3_subject = course_details.get('leo3_inst')[0]
-            leo5_data = leo3_subject = course_details.get('leo5_inst')[0]
-
-            if 'subject' in go_salary_inst_data:
-                go_salary_inst_subject = go_salary_inst_data['subject']
-                self.title_form_salary_data = go_salary_inst_subject['english_label']
-                if self.display_language == enums.languages.WELSH:
-                    self.title_form_salary_data = go_salary_inst_subject['welsh_label']
-
-            if 'subject' in leo3_data:
-                leo3_subject = leo3_data['subject']
-                self.title_form_salary_data = leo3_subject['english_label']
-                if self.display_language == enums.languages.WELSH:
-                    self.title_form_salary_data = leo3_subject['welsh_label']
-
-            if 'subject' in leo5_data:
-                leo5_subject = leo5_data['subject']
-                self.title_form_salary_data = leo5_subject['english_label']
-                if self.display_language == enums.languages.WELSH:
-                    self.title_form_salary_data = leo5_subject['welsh_label']
-
             self.honours_award_provision = course_details.get('honours_award_provision')
 
             institution = course_details.get('institution')
@@ -1826,6 +1799,7 @@ class Salary:
             self.subject_code = subject_data.get('code', '')
             self.subject_english = subject_data.get('english_label', '')
             self.subject_welsh = subject_data.get('welsh_label', '')
+            self.subject_title_in_local_language = self.subject_english
 
             # TODO Why do we need two of those?
             self.unavail_reason = salary_data['unavail_reason']
@@ -1890,6 +1864,7 @@ class Salary:
                     self.earnings_aggregation_str = salary_data['earnings_agg_unavail_message']['english']
                 else:
                     self.earnings_aggregation_str = salary_data['earnings_agg_unavail_message']['welsh']
+                    self.subject_title_in_local_language = self.subject_welsh
 
                 self.earnings_aggregation_msg["msg_heading"], self.earnings_aggregation_msg["msg_body"] = separate_unavail_reason(self.earnings_aggregation_str)
 

--- a/courses/templates/courses/partials/earnings_after_the_course_body.html
+++ b/courses/templates/courses/partials/earnings_after_the_course_body.html
@@ -262,19 +262,19 @@
                                         {% get_translation key='prov_pc_text_template_leo' language=page.get_language as prov_pc_text_template_leo %}
                                         {% if salary_index == 0 and salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc != None %}
                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                                                {% create_list salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                {% create_list salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc course_details.title_form_salary_data course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                 {% insert_values_to_plain_text content=prov_pc_text_template_go substitutions=substitutions as subbed_text %}
                                                 {{ subbed_text | richtext }}
                                             </h4>
                                         {% elif salary_index == 1 and salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc != None %}
                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                                                {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc course_details.title_form_salary_data course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                 {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                                                 {{ subbed_text | richtext }}
                                             </h4>
                                         {% elif salary_index == 2 and salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc != None %}
                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                                                {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc course_details.title_form_salary_data course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                 {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                                                 {{ subbed_text | richtext }}
                                             </h4>

--- a/courses/templates/courses/partials/earnings_after_the_course_body.html
+++ b/courses/templates/courses/partials/earnings_after_the_course_body.html
@@ -262,19 +262,19 @@
                                         {% get_translation key='prov_pc_text_template_leo' language=page.get_language as prov_pc_text_template_leo %}
                                         {% if salary_index == 0 and salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc != None %}
                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                                                {% create_list salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc course_details.title_form_salary_data course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                {% create_list salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                 {% insert_values_to_plain_text content=prov_pc_text_template_go substitutions=substitutions as subbed_text %}
                                                 {{ subbed_text | richtext }}
                                             </h4>
                                         {% elif salary_index == 1 and salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc != None %}
                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                                                {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc course_details.title_form_salary_data course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.1.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                 {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                                                 {{ subbed_text | richtext }}
                                             </h4>
                                         {% elif salary_index == 2 and salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc != None %}
                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                                                {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc course_details.title_form_salary_data course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.2.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                 {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                                                 {{ subbed_text | richtext }}
                                             </h4>


### PR DESCRIPTION
The 'Earnings after the Course' Subject name for each salary band (leo3, leo5, go_salary) now comes from either one of the salary bands (leo3, leo5, go_salary) that has salary information (as some of them only have unavailable messages.
The reason this is done in the Course class and not in the individual Salary classes is because some part of the code removes any additional variables attached to the Salary class (I don't know how or why)

Testing

http://localhost:8000/course-details/10007767/UMDAHFY/Full-time/
http://localhost:8000/course-details/10007165/U09FUECW/Full-time/