### PR TITLE
forgot to fix salary course titles for the comparison earnings after …

### DIFF
--- a/courses/templates/courses/partials/comparison_earnings_after_the_course_body.html
+++ b/courses/templates/courses/partials/comparison_earnings_after_the_course_body.html
@@ -280,13 +280,13 @@
                                                             </h4>
                                                         {% elif salary_index == 1 and salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc != None %}
                                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code '_' l_or_r %}">
-                                                                {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                                {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.1.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                                 {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                                                                 {{ subbed_text | richtext }}
                                                             </h4>
                                                         {% elif salary_index == 2 and salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc != None %}
                                                             <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3" id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code '_' l_or_r %}">
-                                                                {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                                                                {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.2.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
                                                                 {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                                                                 {{ subbed_text | richtext }}
                                                             </h4>


### PR DESCRIPTION
…the course

### What

Changed which array position each salary title points at

### How to review

1. Bookmark two courses
2. Compare the two courses
3. Look at the salary information and make sure the course titles are there (look here -> https://t2573811.p.clickup-attachments.com/t2573811/fcd628a4-e9ef-4763-9948-c0af6586e206/image.png?view=open for an example)
4. Check the same for when the site is in welsh
