### PR TITLE
close active pill fix

### DIFF
--- a/coursefinder/templates/coursefinder/partials/active_filters.html
+++ b/coursefinder/templates/coursefinder/partials/active_filters.html
@@ -3,7 +3,7 @@
     <script>
         // a function to select the value the passed in value for study_mode and set it to null
         function closeFilter(filter) {  
-          document.getElementById(filter).value = null;
+          document.getElementById(filter).checked = false;
           document.getElementById("filterForm").submit()
         }
    


### PR DESCRIPTION
Fix for closing currently active filters using pills.

Rather than submitting a value to the form directly, the JS unchecks the filter and sends the form