### PR TITLE
fixed JS for radiobuttons, locations disabled if only distance learni…

### DIFF
--- a/CMS/static/scss/partials/filters.scss
+++ b/CMS/static/scss/partials/filters.scss
@@ -158,6 +158,13 @@
                 cursor: pointer;
             }
 
+        &-disabled {
+            padding: 10px;
+            background-color: $pale;
+            font-family: "Nunito Sans", sans-serif;
+            font-size: 16px;
+        }
+
         &-years-group {
             margin: 0px -33px;
         }
@@ -612,6 +619,11 @@
                         }
                     }
                 }
+            }
+
+            &-disabled {
+                width: 255px;
+                transform: translate(-10px)
             }
 
             &-years-group {

--- a/CMS/static/scss/variables.scss
+++ b/CMS/static/scss/variables.scss
@@ -30,6 +30,7 @@ $default-font-color: $black;
 $bruise: #8e3b74;
 $very-light-blue: #e9ecef;
 $greyish-brown: #595959;
+$pale: #fef7d7;
 
 $xl-heading-font-size: 70px;
 $xl-heading-line-height: 70px;

--- a/CMS/translations.py
+++ b/CMS/translations.py
@@ -441,6 +441,10 @@ DICT = {
         'en': 'Filter by',
         'cy': 'Hidlo gan'
     },
+    'filter_not_applicable':{
+        'en': 'The filter is not applicable for distance learning courses.',
+        'cy': "Nid yw'r hidlydd hwn yn berthnasol i gyrsiau dysgu o bell."
+    },
     'financial_support_details': {
         'en': 'Financial support',
         'cy': 'Cymorth ariannol'

--- a/coursefinder/templates/coursefinder/partials/location_filters.html
+++ b/coursefinder/templates/coursefinder/partials/location_filters.html
@@ -1,16 +1,16 @@
 {% load discover_uni_tags wagtailcore_tags %}
 <script>
-	$(document).ready(function() {
-	   $('input[type="radio"]').click(function() {
-	       if($(this).attr('id') == 'region') {
-	            $('#regionDiv').show();           
-	       }
+    $(document).ready(function() {
+       $('input[type="radio"]').click(function() {
+           if($(this).attr('id') == 'region') {
+                $('.region-div').css( "display", "block" );           
+           }
 
-	       else if($(this).attr('id') == 'postcode') {
-	            $('#regionDiv').hide();   
-	       }
-	   });
-	});
+           else if($(this).attr('id') == 'postcode') {
+                $('.region-div').css( "display", "none" );   
+           }
+       });
+    });
 </script>
 
 <div class="filters-block__filter-accordion">
@@ -31,30 +31,40 @@
     </div>
 
     <div class="filters-block__filter-accordion-body">
-    	<div class="filters-block__filter-options-title">
-	    	{% get_translation key='filter_by' language=page.get_language %}
-	    </div>
-    	<div class="filters-block__filter-option-location">
-	    	<input type="radio" id="region" class="filters-block__filter-radio" name="location" value="region">
-		    <label class="filters-block__filter-radio-label" for="region">{% get_translation key='regions' language=page.get_language %}</label><br>
-		    <input type="radio" id="postcode" class="filters-block__filter-radio" name="location" value="postcode">
-		    <label class="filters-block__filter-radio-label" for="postcode">{% get_translation key='postcode' language=page.get_language %}</label><br>
-		</div>
+        {% if filter_form.mode_query == "Distance learning" %}
+        <div class="filters-block__filter-disabled">
+            {% get_translation key='filter_not_applicable' language=page.get_language %}
+        </div>
+        {% endif %}
 
-        <div id="regionDiv" class="filters-block__filter-options" style="display: none;">
+        <div class="filters-block__filter-options-title">
+            {% get_translation key='filter_by' language=page.get_language %}
+        </div>
+        <div class="filters-block__filter-option-location">
+            <input type="radio" id="region" class="filters-block__filter-radio" name="location" value="region"
+            {% if filter_form.mode_query == "Distance learning" %}disabled='disabled'{% endif %}>
+            <label class="filters-block__filter-radio-label" for="region">{% get_translation key='regions' language=page.get_language %}</label><br>
+            <input type="radio" id="postcode" class="filters-block__filter-radio" name="location" value="postcode"
+            {% if filter_form.mode_query == "Distance learning" %}disabled='disabled'{% endif %}>
+            <label class="filters-block__filter-radio-label" for="postcode">{% get_translation key='postcode' language=page.get_language %}</label><br>
+        </div>
 
-        	<div class="filters-block__filter-option-country">
+        <div id="regionDiv" class="filters-block__filter-options region-div">
+
+            <div class="filters-block__filter-option-country">
                 <input id="countries-england" class="filters-block__filter-checkbox-input" type="checkbox" name="countries_query" value="England"
-                    {% if 'England' in filter_form.countries_query %}checked{% endif %} />
+                    {% if 'England' in filter_form.countries_query %}checked{% endif %}
+                    {% if filter_form.mode_query == "Distance learning" %}disabled='disabled'{% endif %} />
 
                 <label class="filters-block__filter-checkbox-label-bold" for="countries-england">
                     {% get_translation key='england' language=page.get_language %}
                 </label>
             </div>
 
-        	<div class="filters-block__filter-option-country">
+            <div class="filters-block__filter-option-country">
                 <input id="countries-scotland" class="filters-block__filter-checkbox-input" type="checkbox" name="countries_query" value="Scotland"
-                    {% if 'Scotland' in filter_form.countries_query %}checked{% endif %} />
+                    {% if 'Scotland' in filter_form.countries_query %}checked{% endif %}
+                    {% if filter_form.mode_query == "Distance learning" %}disabled='disabled'{% endif %} />
 
                 <label class="filters-block__filter-checkbox-label-bold" for="countries-scotland">
                     {% get_translation key='scotland' language=page.get_language %}
@@ -63,7 +73,8 @@
 
             <div class="filters-block__filter-option-country">
                 <input id="countries-ireland" class="filters-block__filter-checkbox-input" type="checkbox" name="countries_query" value="Northern Ireland"
-                    {% if 'Northern Ireland' in filter_form.countries_query %}checked{% endif %} />
+                    {% if 'Northern Ireland' in filter_form.countries_query %}checked{% endif %}
+                    {% if filter_form.mode_query == "Distance learning" %}disabled='disabled'{% endif %} />
 
                 <label class="filters-block__filter-checkbox-label-bold" for="countries-ireland">
                     {% get_translation key='northern_ireland' language=page.get_language %}
@@ -72,7 +83,8 @@
 
             <div class="filters-block__filter-option-country">
                 <input id="countries-wales" class="filters-block__filter-checkbox-input" type="checkbox" name="countries_query" value="Wales"
-                    {% if 'Wales' in filter_form.countries_query %}checked{% endif %} />
+                    {% if 'Wales' in filter_form.countries_query %}checked{% endif %}
+                    {% if filter_form.mode_query == "Distance learning" %}disabled='disabled'{% endif %} />
 
                 <label class="filters-block__filter-checkbox-label-bold" for="countries-wales">
                     {% get_translation key='wales' language=page.get_language %}


### PR DESCRIPTION
Clicking the postcode button now hides the region options when in mobile view.

Now no longer able to select anything in the locations filter if the only applied filter is Distance learning. There is a text box to indicate this.
