### PR TITLE
F76egb learning filters on campus

### DIFF
--- a/CMS/static/js/filters.js
+++ b/CMS/static/js/filters.js
@@ -450,9 +450,10 @@ function toggleDistance(distance_checked, campus_checked) {
             disable_countries.attr('disabled', false);
             disable_postcode.attr('disabled', false);
 
-            if(!($('[name="postcode"]').val()) || (!($('[name="distance"]').val()))){
+            if($('.filters-block__filter-radio-postcode').is(":checked") && ((!($('[name="postcode"]').val())) || (!($('[name="distance"]').val())))){
                 $('.filters-block__submit-btn').css('background-color', "grey"); 
                 $('.filters-block__submit-btn').prop('disabled', true);
+
             }
 
             if(!($('[name="postcode"]').val())){
@@ -478,7 +479,7 @@ function toggleDistance(distance_checked, campus_checked) {
             disable_countries.attr('disabled', false);
             disable_postcode.attr('disabled', false);
 
-            if(!($('[name="postcode"]').val()) || (!($('[name="distance"]').val()))){
+            if($('.filters-block__filter-radio-postcode').is(":checked") && ((!($('[name="postcode"]').val())) || (!($('[name="distance"]').val())))){
                 $('.filters-block__submit-btn').css('background-color', "grey"); 
                 $('.filters-block__submit-btn').prop('disabled', true);
             }

--- a/CMS/static/js/filters.js
+++ b/CMS/static/js/filters.js
@@ -432,6 +432,7 @@
 
 function toggleDistance(distance_checked, campus_checked) {
     var disable_countries = $('input[name=countries_check]');
+    var disable_radio = $('input[name=location_radio]');
     var disable_postcode = $('.postcode-fieldset')
     var distance_checked_mobile = document.getElementsByClassName('distance')[1].checked;
     var campus_checked_mobile = document.getElementsByClassName('campus')[1].checked;
@@ -440,6 +441,7 @@ function toggleDistance(distance_checked, campus_checked) {
         if(distance_checked && campus_checked == false){
             $(".message").css( "display", "block" )
             disable_countries.attr('disabled', 'disabled');
+            disable_radio.attr('disabled', 'disabled');
             disable_postcode.attr('disabled', 'disabled');
             disable_postcode.css('border', '1px solid grey')
             $('.filters-block__submit-btn').prop('disabled', false);
@@ -448,6 +450,7 @@ function toggleDistance(distance_checked, campus_checked) {
         else{
             $(".message").css( "display", "none" )
             disable_countries.attr('disabled', false);
+            disable_radio.attr('disabled', false);
             disable_postcode.attr('disabled', false);
 
             if($('.filters-block__filter-radio-postcode').is(":checked") && ((!($('[name="postcode"]').val())) || (!($('[name="distance"]').val())))){
@@ -469,6 +472,7 @@ function toggleDistance(distance_checked, campus_checked) {
         if(distance_checked_mobile && campus_checked_mobile == false){
             $(".message").css( "display", "block" )
             disable_countries.attr('disabled', 'disabled');
+            disable_radio.attr('disabled', 'disabled');
             disable_postcode.attr('disabled', 'disabled');
             $('.filters-block__submit-btn').prop('disabled', false);
             $('.filters-block__submit-btn').css('background-color', "#8e3b74"); 
@@ -477,6 +481,7 @@ function toggleDistance(distance_checked, campus_checked) {
         else {
             $(".message").css( "display", "none" )
             disable_countries.attr('disabled', false);
+            disable_radio.attr('disabled', false);
             disable_postcode.attr('disabled', false);
 
             if($('.filters-block__filter-radio-postcode').is(":checked") && ((!($('[name="postcode"]').val())) || (!($('[name="distance"]').val())))){
@@ -568,21 +573,41 @@ $(document).ready(function() {
         }
     });
 });
+
+
+//Check on load whether the postcode radio button is checked and then display the postcode div if true.
+//Make sure borders of inputs aren't red as these will have to be prefilled anyway.
+$(document).ready(function() {
+    if($('.filters-block__filter-radio-postcode').is(":checked")){
+        $('.region-div').css( "display", "none" );
+        $('.filters-block__filter-postcode-div').css( "display", "flex" );    
+        $('[name="countries_query"]').prop('disabled', true);
+        $('[name="distance"]').prop('disabled', false);
+        $('[name="postcode"]').prop('disabled', false);
+        $('[name="postcode"]').css( "border", "1px solid #595959" )
+        $('[name="distance"]').css( "border", "1px solid #595959" )
+    }
+});
 //function to check whether distance is checked on page load and to disable the location filters if it is.
 $(document).ready(function() {
     var disable_input = $('input[name=countries_check]');
+    var disable_radio = $('input[name=location_radio]');
     if($('.distance').is(":checked") == true && $('.campus').is(":checked") == false){
         disable_input.attr('disabled', 'disabled');
+        disable_radio.attr('disabled', 'disabled')
         $(".message").css( "display", "block" )
     }
 });
 
 $(document).ready(function(){
     $('#clear-filters').click(function(){
+        $('.filters-block__filter-radio-region').prop('checked', true)
         $('#countries-england').prop('checked', false);
         $('#countries-ireland').prop('checked', false);
         $('#countries-scotland').prop('checked', false);
         $('#countries-wales').prop('checked', false);
+        $('[name="distance"]').val('')
+        $('[name="postcode"]').val('')
 
         $('#mode-full-time').prop('checked', false);
         $('#mode-part-time').prop('checked', false);

--- a/coursefinder/forms.py
+++ b/coursefinder/forms.py
@@ -13,7 +13,8 @@ class FilterForm:
             else ''
         self.courses = form_data.get('subject_query', '')
         self.course_query = form_data.get('course_query', '')
-        self.postcode_query = form_data.get('postcode_query', '')
+        self.postcode_query = (form_data.get('postcode') + ',' + form_data.get('distance')) if form_data.get('postcode') != None \
+            and form_data.get('postcode') != '' else {}
         if self.postcode_query:
             self.postcode = self.postcode_query.split(',')[0]
             self.distance = self.postcode_query.split(',')[1]

--- a/coursefinder/templates/coursefinder/partials/active_filters.html
+++ b/coursefinder/templates/coursefinder/partials/active_filters.html
@@ -167,7 +167,6 @@
 
             {% endif %}
         {% endif %}
-        
         {% if postcode_query|length > 0 %}
 
                 <div class="filters-block__filter-pill">

--- a/coursefinder/templates/coursefinder/partials/location_filters.html
+++ b/coursefinder/templates/coursefinder/partials/location_filters.html
@@ -26,9 +26,9 @@
             {% get_translation key='filter_by' language=page.get_language %}
         </div>
         <div class="filters-block__filter-option-location">
-            <input type="radio" id="region" class="filters-block__filter-radio" name="countries_check" value="region">
+            <input type="radio" id="region" class="filters-block__filter-radio-region" name="location_radio" value="region"checked>
             <label class="filters-block__filter-radio-label" for="region">{% get_translation key='regions' language=page.get_language %}</label><br>
-            <input type="radio" id="postcode" class="filters-block__filter-radio-postcode" name="countries_check" value="postcode">
+            <input type="radio" id="postcode" class="filters-block__filter-radio-postcode" name="location_radio" value="postcode" {% if filter_form.postcode_query %}checked{% endif %}>
             <label class="filters-block__filter-radio-label" for="postcode">{% get_translation key='postcode' language=page.get_language %}</label><br>
         </div>
 
@@ -81,7 +81,7 @@
 
         <div class="filters-block__filter-postcode-div">
             <label for="postcode_field" class="filters-block__filter-checkbox-label-bold">{% get_translation key='postcode' language=page.get_language %}</label>
-            <input style="margin-bottom: 20px;" id="postcode_field" class="filters-block__filter-postcode-div-textfield postcode-fieldset" type="text" name="postcode" value="" disabled required />
+            <input style="margin-bottom: 20px;" id="postcode_field" class="filters-block__filter-postcode-div-textfield postcode-fieldset" type="text" name="postcode" {% if filter_form.postcode %} value="{{filter_form.postcode}}" {% endif %} disabled required />
 
             <label for="postcode-distance" class="filters-block__filter-checkbox-label-bold">{% get_translation key='distance' language=page.get_language %}</label>
             <select id="postcode-distance" name="distance" class="filters-block__filter-postcode-div-textfield postcode-fieldset" disabled>
@@ -89,27 +89,26 @@
                                         value="">
                 </option>
                 <option class="filters-block__filter-postcode-div-question"
-                                        id="ten_miles" placeholder="Within 10 miles"  value="10">
+                                        id="ten_miles" placeholder="Within 10 miles"  value="10" {% if filter_form.distance == '10' %}selected{% endif %}>
                 </option>
                 <option class="filters-block__filter-postcode-div-question"
-                                        id="twenty_five_miles" placeholder="Within 25 miles"  value="25">
+                                        id="twenty_five_miles" placeholder="Within 25 miles" value="25" {% if filter_form.distance == '25' %}selected{% endif %}>
                 </option>
                 <option class="filters-block__filter-postcode-div-question"
-                                        id="fifty_miles" placeholder="Within 50 miles"  value="50">
+                                        id="fifty_miles" placeholder="Within 50 miles"  value="50" {% if filter_form.distance == '50' %}selected{% endif %}>
                 </option>
             </select>
 
-        <script>
-            ten_miles = document.getElementById("ten_miles")
-            twenty_five_miles = document.getElementById("twenty_five_miles")
-            fifty_miles = document.getElementById("fifty_miles")
+            <script>
+                ten_miles = document.getElementById("ten_miles")
+                twenty_five_miles = document.getElementById("twenty_five_miles")
+                fifty_miles = document.getElementById("fifty_miles")
 
 
-            ten_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '10')
-            twenty_five_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '25')
-            fifty_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '50')
-        </script>
+                ten_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '10')
+                twenty_five_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '25')
+                fifty_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '50')
+            </script>
         </div>
-
     </div>
 </div>

--- a/coursefinder/templates/coursefinder/partials/location_filters.html
+++ b/coursefinder/templates/coursefinder/partials/location_filters.html
@@ -28,7 +28,7 @@
         <div class="filters-block__filter-option-location">
             <input type="radio" id="region" class="filters-block__filter-radio" name="countries_check" value="region">
             <label class="filters-block__filter-radio-label" for="region">{% get_translation key='regions' language=page.get_language %}</label><br>
-            <input type="radio" id="postcode" class="filters-block__filter-radio" name="countries_check" value="postcode">
+            <input type="radio" id="postcode" class="filters-block__filter-radio-postcode" name="countries_check" value="postcode">
             <label class="filters-block__filter-radio-label" for="postcode">{% get_translation key='postcode' language=page.get_language %}</label><br>
         </div>
 

--- a/coursefinder/views.py
+++ b/coursefinder/views.py
@@ -88,9 +88,10 @@ def course_finder_results(request, language=enums.languages.ENGLISH):
 
     institution_query = '@'.join(query_params.getlist('institution_query')) if 'institution_query' in query_params else None
     
-    postcode = query_params.getlist('postcode') if 'postcode' in query_params else None
-    distance_query = query_params.getlist('distance') if 'distance' in query_params else None
-    postcode_query = ','.join(postcode + distance_query) if 'postcode' and 'distance' in query_params else None
+    postcode = query_params.get('postcode') if 'postcode' in query_params else None
+    distance_query = query_params.get('distance') if 'distance' in query_params else None
+    postcode_query = (postcode + ',' + distance_query) if postcode and distance_query else {}
+
     sort_by_subject_enabled = query_params.get('sort_by_subject', 'false')
     sort_by_subject_limit = int(os.environ.get('SORT_BY_SUBJECT_LIMIT', 5000))
     count = sort_by_subject_limit if sort_by_subject_enabled == 'true' else 20
@@ -140,7 +141,7 @@ def course_finder_results(request, language=enums.languages.ENGLISH):
         'filters': filters,
         'postcode_query': postcode_query,
         'sort_by_subject_enabled': sort_by_subject_enabled,
-        'sort_by_subject_limit': sort_by_subject_limit,        
+        'sort_by_subject_limit': sort_by_subject_limit,  
     })
 
     return render(request, 'coursefinder/course_finder_results.html', context)


### PR DESCRIPTION
The apply filters button needs to be disabled if either postcode field is blank. JS has been fixed so that if distance learning is checked and on campus isn't, the button is enabled. Just ticking on campus no longer disables the button.

Added JS to enable the button before sending the form so that a load error doesn't occur.

The postcode is now sent through a form, rather than just query params - the form values are preserved and pre-filled into the postcode form on page load.

Region radio button is now checked on load by default -  the postcode radio  is checked and div is preloaded if the user filtered with a postcode.
