### PR TITLE
distance label fix

### DIFF
--- a/CMS/templates/partials/course_result.html
+++ b/CMS/templates/partials/course_result.html
@@ -10,7 +10,7 @@
         if(distance === "Course is only available through distance learning" ){
             distance_array.push("distance")
         }
-        if(distance === "Course is optionally available through distance learning" && '{{filter_form.countries_query}}'.includes(country) === false){
+        else if(distance === "Course is optionally available through distance learning" && "{{postcode_query}}" === "{}" && "{{filter_form.countries_query}}".includes(country) === false){
             distance_array.push("distance")
         }
         else{


### PR DESCRIPTION
Corrected function to use an if else statement, the distance learning label should now be correctly applied to "optionally available through distance learning".

Added an if statement to avoid any confusion over said labels when a postcode filter has been applied.