### PR TITLE
G95r2y postcode filter

### DIFF
--- a/CMS/static/js/filters.js
+++ b/CMS/static/js/filters.js
@@ -444,7 +444,8 @@ function toggleDistance(distance_checked, campus_checked) {
             disable_countries.attr('disabled', 'disabled');
             disable_radio.attr('disabled', 'disabled');
             disable_postcode.attr('disabled', 'disabled');
-            disable_postcode.css('border', '1px solid grey')
+            disable_postcode.css('border', '1px solid grey');
+            $(".distance-dropdown").css("pointer-events", "none");
             $('.filters-block__submit-btn').prop('disabled', false);
             $('.filters-block__submit-btn').css('background-color', "#8e3b74"); 
         }
@@ -453,11 +454,15 @@ function toggleDistance(distance_checked, campus_checked) {
             disable_countries.attr('disabled', false);
             disable_radio.attr('disabled', false);
             disable_postcode.attr('disabled', false);
+            $(".distance-dropdown").css("pointer-events", "auto");
 
-            if($('.filters-block__filter-radio-postcode').is(":checked") && ((!($('[name="postcode"]').val())) || (!($('[name="distance"]').val())))){
-                $('.filters-block__submit-btn').css('background-color', "grey"); 
+            if($('[name="distance"]').val() && $('[name="postcode"]').val()){
+                $('.filters-block__submit-btn').prop('disabled', false);
+                $('.filters-block__submit-btn').css('background-color', "#8e3b74");
+            }
+            else if($('.filters-block__filter-radio-postcode').is(":checked") && ($('[name="postcode"]').val() !== $('[name="distance"]').val())){
+                $('.filters-block__submit-btn').css('background-color', "grey");
                 $('.filters-block__submit-btn').prop('disabled', true);
-
             }
 
             if(!($('[name="postcode"]').val()) && $('[name="distance"]').val()){
@@ -465,7 +470,7 @@ function toggleDistance(distance_checked, campus_checked) {
             }
 
             if(!($('[name="distance"]').val()) && $('[name="postcode"]').val()){
-                $('[name="distance"]').css( "border", "1px solid red" )
+                $('.distance-dropdown').css( "border", "1px solid red" )
             }
         }
     }
@@ -484,9 +489,14 @@ function toggleDistance(distance_checked, campus_checked) {
             disable_countries.attr('disabled', false);
             disable_radio.attr('disabled', false);
             disable_postcode.attr('disabled', false);
+            $(".distance-dropdown").css("pointer-events", "auto");
 
-            if($('.filters-block__filter-radio-postcode').is(":checked") && ((!($('[name="postcode"]').val())) || (!($('[name="distance"]').val())))){
-                $('.filters-block__submit-btn').css('background-color', "grey"); 
+            if($('[name="distance"]').val() && $('[name="postcode"]').val()){
+                $('.filters-block__submit-btn').prop('disabled', false);
+                $('.filters-block__submit-btn').css('background-color', "#8e3b74");
+            }
+            else if($('.filters-block__filter-radio-postcode').is(":checked") && ($('[name="postcode"]').val() !== $('[name="distance"]').val())){
+                $('.filters-block__submit-btn').css('background-color', "grey");
                 $('.filters-block__submit-btn').prop('disabled', true);
             }
 
@@ -495,7 +505,7 @@ function toggleDistance(distance_checked, campus_checked) {
             }
 
             if(!($('[name="distance"]').val()) && $('[name="postcode"]').val()){
-                $('[name="distance"]').css( "border", "1px solid red" )
+                $('.distance-dropdown').css( "border", "1px solid red" )
             }
         }
     }
@@ -521,6 +531,21 @@ function toggleCheckbox(country) {
            hidden[1].checked = false; 
         } 
     }
+}
+
+function selectDistance(id){
+    var dropdownText = $(".filters-block__filter-postcode-div-dropdown-text");
+    var distanceValue = $('[name="distance"]');
+
+        if(id !== ""){
+            dropdownText.text(translation.replace("{}", id))
+        }
+        else{
+            dropdownText.text("")
+        }
+
+    distanceValue.val(id);
+    distanceValue.trigger('change');
 }
 
 $(document).ready(function() {
@@ -560,30 +585,35 @@ $(document).ready(function() {
 
 $(document).ready(function() {
    $('.postcode-fieldset').change(function() {
-
-        if($('[name="postcode"]').val() && $('[name="distance"]').val()){
+        if(window.innerWidth > 576){
+            var postcode = $('[name="postcode"]')[0]
+        }
+        else{
+            var postcode = $('[name="postcode"]')[1]
+        }
+        if(postcode.value && $('[name="distance"]').val()){
             $('.filters-block__submit-btn').prop('disabled', false);
             $('.filters-block__submit-btn').css('background-color', "#8e3b74");
         }
-        else if($('[name="postcode"]').val() === $('[name="distance"]').val()){
+        else if(postcode.value === $('[name="distance"]').val()){
             $('.filters-block__submit-btn').prop('disabled', false);
             $('.filters-block__submit-btn').css('background-color', "#8e3b74");
         }
-        else if($('[name="postcode"]').val() !== $('[name="distance"]').val()){
+        else if(postcode.value !== $('[name="distance"]').val()){
             $('.filters-block__submit-btn').prop('disabled', true);
             $('.filters-block__submit-btn').css('background-color', "grey");
         }
-        if(!($('[name="postcode"]').val()) && $('[name="distance"]').val()){
+        if(!(postcode.value) && $('[name="distance"]').val()){
             $('[name="postcode"]').css( "border", "1px solid red" )
         }
         else{
             $('[name="postcode"]').css( "border", "1px solid #595959" )
         }
-        if(!($('[name="distance"]').val()) && $('[name="postcode"]').val()){
-            $('[name="distance"]').css( "border", "1px solid red" )
+        if(!($('[name="distance"]').val()) && postcode.value){
+            $('.distance-dropdown').css( "border", "1px solid red" )
         }
         else{
-            $('[name="distance"]').css( "border", "1px solid #595959" )
+            $('.distance-dropdown').css( "border", "1px solid #595959" )
         }
     });
 });

--- a/CMS/static/scss/partials/filters.scss
+++ b/CMS/static/scss/partials/filters.scss
@@ -165,8 +165,7 @@
                     z-index: 1;
                     background-color: white;
                     width: 100%;
-                    border: 1px solid #595959;
-                    border-radius: 2px;
+                    box-shadow: rgba(0, 0, 0, 0.4) 3px 3px 4px 0px;
 
                 }
                 &-item{

--- a/CMS/static/scss/partials/filters.scss
+++ b/CMS/static/scss/partials/filters.scss
@@ -132,6 +132,7 @@
                 height: 35px;
                 border: 1px solid #595959;
                 border-radius: 2px;
+                padding-left: 5px;
             }
 
             &-question{
@@ -142,6 +143,38 @@
 
                 line-height: 45px;
                 color: $ux-grey-3;
+            }
+
+            &-dropdown{
+                border: 1px solid #595959;
+                border-radius: 2px;
+                height: 35px;
+                position: relative;
+                cursor: pointer;
+
+                &-text{
+                    display: inline-block;
+                    line-height: 34px;
+                    vertical-align: middle;
+                    padding-left: 5px;
+                }
+
+                &-body{
+                    display: none;
+                    position: absolute;
+                    z-index: 1;
+                    background-color: white;
+                    width: 100%;
+                    border: 1px solid #595959;
+                    border-radius: 2px;
+
+                }
+                &-item{
+                    padding-left: 5px;
+                }
+                &-item:hover{
+                    background-color: #ced4da;
+                }
             }
         }
 

--- a/coursefinder/templates/coursefinder/partials/location_filters.html
+++ b/coursefinder/templates/coursefinder/partials/location_filters.html
@@ -1,4 +1,15 @@
 {% load discover_uni_tags wagtailcore_tags %}
+<script>
+    var ten_miles = document.getElementsByClassName("ten_miles")
+    var twenty_five_miles = document.getElementsByClassName("twenty_five_miles")
+    var fifty_miles = document.getElementsByClassName("fifty_miles")
+    var distance_value = document.getElementsByClassName("filters-block__filter-postcode-div-dropdown-text")
+    var form_value = "{{filter_form.distance}}"
+
+    var dropdownText = document.getElementsByClassName("filters-block__filter-postcode-div-dropdown-text");
+    var distanceValue = document.getElementsByClassName("distance-value");
+    var translation = "{% get_translation key='within_miles' language=page.get_language %}"
+</script>
 
 <div class="filters-block__filter-accordion">
     <div tabindex="0" role="button" aria-label="Show content" class="filters-block__filter-accordion-header">
@@ -81,34 +92,46 @@
 
         <div class="filters-block__filter-postcode-div">
             <label for="postcode_field" class="filters-block__filter-checkbox-label-bold">{% get_translation key='postcode' language=page.get_language %}</label>
-            <input style="margin-bottom: 20px;" id="postcode_field" class="filters-block__filter-postcode-div-textfield postcode-fieldset" type="text" name="postcode" {% if filter_form.postcode %} value="{{filter_form.postcode}}" {% endif %} disabled required />
+            <input style="margin-bottom: 20px;" id="postcode_field" class="filters-block__filter-postcode-div-textfield postcode-fieldset" type="text" name="postcode" {% if filter_form.postcode %} value="{{filter_form.postcode}}" {% endif %} disabled />
 
             <label for="postcode-distance" class="filters-block__filter-checkbox-label-bold">{% get_translation key='distance' language=page.get_language %}</label>
-            <select id="postcode-distance" name="distance" class="filters-block__filter-postcode-div-textfield postcode-fieldset" disabled>
+            <div onclick="$('.filters-block__filter-postcode-div-dropdown-body').toggle();" class="filters-block__filter-postcode-div-dropdown distance-dropdown postcode-fieldset">
+                <div class="filters-block__filter-postcode-div-dropdown-text">{{filter_form.distance}}</div>
+                <div style="display: inline; float: right; padding-right: 5px; font-weight: bold;">&#x2304;</div>
+                <div class="filters-block__filter-postcode-div-dropdown-body distance-content">
+                    <div class="filters-block__filter-postcode-div-dropdown-item" onclick="selectDistance('');" style="height: 23px;"></div>
+                    <div class="filters-block__filter-postcode-div-dropdown-item ten_miles" onclick="selectDistance(10);"></div>
+                    <div class="filters-block__filter-postcode-div-dropdown-item twenty_five_miles" onclick="selectDistance(25);"></div>
+                    <div class="filters-block__filter-postcode-div-dropdown-item fifty_miles" onclick="selectDistance(50);"></div>
+                </div>
+            </div>
+
+            <script>
+                for(var i = 0; i < 2; i++){
+                    if(ten_miles[i]){
+                        ten_miles[i].innerHTML = translation.replace("{}", 10);
+                        twenty_five_miles[i].innerHTML= translation.replace("{}", 25);
+                        fifty_miles[i].innerHTML = translation.replace("{}", 50);
+                        if(form_value){
+                            distance_value[i].innerHTML = translation.replace("{}", form_value);
+                        };
+                    };
+                };
+            </script>
+            <select id="postcode-distance" name="distance" class="filters-block__filter-postcode-div-textfield postcode-fieldset distance-value" hidden disabled>
                 <option class="filters-block__filter-postcode-div-question"
                                         value="">
                 </option>
                 <option class="filters-block__filter-postcode-div-question"
-                                        id="ten_miles" placeholder="Within 10 miles"  value="10" {% if filter_form.distance == '10' %}selected{% endif %}>
+                        placeholder="Within 10 miles"  value="10" {% if filter_form.distance == '10' %}selected{% endif %}>10
                 </option>
                 <option class="filters-block__filter-postcode-div-question"
-                                        id="twenty_five_miles" placeholder="Within 25 miles" value="25" {% if filter_form.distance == '25' %}selected{% endif %}>
+                        placeholder="Within 25 miles" value="25" {% if filter_form.distance == '25' %}selected{% endif %}>25
                 </option>
                 <option class="filters-block__filter-postcode-div-question"
-                                        id="fifty_miles" placeholder="Within 50 miles"  value="50" {% if filter_form.distance == '50' %}selected{% endif %}>
+                        placeholder="Within 50 miles"  value="50" {% if filter_form.distance == '50' %}selected{% endif %}>50
                 </option>
             </select>
-
-            <script>
-                ten_miles = document.getElementById("ten_miles")
-                twenty_five_miles = document.getElementById("twenty_five_miles")
-                fifty_miles = document.getElementById("fifty_miles")
-
-
-                ten_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '10')
-                twenty_five_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '25')
-                fifty_miles.innerHTML = "{% get_translation key='within_miles' language=page.get_language %}".replace('{}', '50')
-            </script>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Option tags are unable to be styled, and when viewed on smaller screens, the the text on the distance dropdowns on the postcode filter was too large.

This has been redone so that a separate dropdown now picks the option, which is now hidden, and has been styled to match the other dropdown menus on the site.

The JS that was originally effecting the distance select dropdown now also effects the new dropdown.
