### PR TITLE
Feature/course comparison h518ca course compare page 1

### DIFF
--- a/CMS/static/scss/partials/compare.scss
+++ b/CMS/static/scss/partials/compare.scss
@@ -1,7 +1,7 @@
 @import '../variables';
 @import '../fonts';
 
-.course-detail__compare-btn {
+.course-detail__compare-btn,  .course-detail__bookmark-compare-btn{
     @include small-font--bold-mixin();
     padding: 5px 10px;
     border: 1.5px solid #266969;
@@ -167,6 +167,15 @@
         @include small-font--bold-mixin();
 
         float: right;
+        padding: 9px 16px 10px 19px;
+
+        border-radius: 16px;
+//         color: $ux-grey-3;
+        color: #fdfafa;
+        background-color: transparent;
+    }
+    .course-detail__bookmark-compare-btn {
+        @include small-font--bold-mixin();
         padding: 9px 16px 10px 19px;
 
         border-radius: 16px;

--- a/courses/models.py
+++ b/courses/models.py
@@ -1435,7 +1435,8 @@ class SatisfactionQuestion:
         if question_data:
             self.show_data_point = 'agree_or_strongly_agree' in question_data
             self.description = fallback_to(question_data.get('description'), '')
-            self.agree_or_strongly_agree = fallback_to(question_data.get('agree_or_strongly_agree'), 0)
+            self.agree_or_strongly_agree = fallback_to(
+                question_data.get('agree_or_strongly_agree'), 0)
 
 
 class TariffStatistics:

--- a/courses/static/js/arrows.js
+++ b/courses/static/js/arrows.js
@@ -2,7 +2,7 @@ var bottom_display = 0;
 const slide_left = document.getElementById("slideLeft");
 const slide_right = document.getElementById("slideRight");
 const course_info_container = document.getElementById("course-info-container")
-if(screen.availWidth < 450 || window.innerWidth < 450){
+if(screen.availWidth <= 320 || window.innerWidth <= 320){
     var small_screen_amount = 1
 }
 else{
@@ -60,7 +60,7 @@ function scrollDisplay(){
 }
 
 function smallScreenDisplay(){
-    if(screen.availWidth < 450 || window.innerWidth < 450){
+    if(screen.availWidth <= 320 || window.innerWidth <= 320){
         var small_screen_amount = 1
     }
     else{
@@ -69,17 +69,23 @@ function smallScreenDisplay(){
     if(bottom_display === 0){
         slide_left.classList.add("hidden");
     }
-    if(!(slide_left.classList.contains("hidden")) && slide_right.classList.contains("hidden")){
+    if(screen.availWidth >= 768 || window.innerWidth >= 768){
+        course_info_container.classList.remove("course-info-right");
+        course_info_container.classList.remove("course-info-left");
+        course_info_container.classList.remove("course-info-both");
+    }
+    else if(!(slide_left.classList.contains("hidden")) && slide_right.classList.contains("hidden")){
         course_info_container.classList.add("course-info-left");
     }
-    if(!(slide_right.classList.contains("hidden")) && slide_left.classList.contains("hidden")){
+    else if(!(slide_right.classList.contains("hidden")) && slide_left.classList.contains("hidden")){
         course_info_container.classList.add("course-info-right");
     }
-    if(!(slide_right.classList.contains("hidden")) && !(slide_left.classList.contains("hidden"))){
+    else if(!(slide_right.classList.contains("hidden")) && !(slide_left.classList.contains("hidden"))){
         course_info_container.classList.remove("course-info-right");
         course_info_container.classList.remove("course-info-left");
         course_info_container.classList.add("course-info-both");
     }
+
 
 
     for(var i=0; i < 8; i++){
@@ -87,11 +93,11 @@ function smallScreenDisplay(){
             var course_info = document.getElementById(dataset[i] + index)
             var course_div = document.getElementById(`courseContainer-${index}`);
 
-            if(screen.availWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||screen.availWidth <= 768 && +course_div.dataset.index < bottom_display){
+            if(screen.availWidth <= 576 && +course_div.dataset.index > bottom_display + small_screen_amount ||screen.availWidth <= 576 && +course_div.dataset.index < bottom_display){
                 course_div.classList.add("hidden");
                 course_info.classList.add("hidden");
             }
-            if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
+            else if(window.innerWidth <= 576 && +course_div.dataset.index > bottom_display + small_screen_amount ||window.innerWidth <= 576 && +course_div.dataset.index < bottom_display){
                 course_div.classList.add("hidden");
                 course_info.classList.add("hidden");
             }

--- a/courses/static/js/arrows.js
+++ b/courses/static/js/arrows.js
@@ -1,0 +1,108 @@
+var bottom_display = 0;
+const slide_left = document.getElementById("slideLeft");
+const slide_right = document.getElementById("slideRight");
+const course_info_container = document.getElementById("course-info-container")
+if(screen.availWidth < 450 || window.innerWidth < 450){
+    var small_screen_amount = 1
+}
+else{
+    var small_screen_amount = 2
+}
+
+function scrollDisplay(){
+    if(bottom_display + small_screen_amount + 1 === compare_list.length){
+        slide_right.classList.add("hidden");
+        course_info_container.classList.remove("course-info-right");
+    }
+    else{
+        slide_right.classList.remove("hidden");
+        course_info_container.classList.add("course-info-right");
+    }
+
+    if(bottom_display === 0){
+        slide_left.classList.add("hidden");
+        course_info_container.classList.remove("course-info-both", "course-info-left");
+    }
+    else{
+        slide_left.classList.remove("hidden");
+        course_info_container.classList.add("course-info-left");
+    }
+    if(!(slide_left.classList.contains("hidden")) && !(slide_right.classList.contains("hidden"))){
+        slide_left.classList.remove("single-arrow");
+        slide_right.classList.remove("single-arrow");
+        slide_left.classList.add("both-arrows");
+        slide_right.classList.add("both-arrows");
+        course_info_container.classList.remove("course-info-left", "course-info-right");
+        course_info_container.classList.add("course-info-both");
+    }
+    else{
+        slide_left.classList.add("single-arrow");
+        slide_right.classList.add("single-arrow");
+        slide_left.classList.remove("both-arrows");
+        slide_right.classList.remove("both-arrows");
+        course_info_container.classList.remove("course-info-both");
+    }
+
+    for(var i=0; i < 8; i++){
+        for(var index=0; index < compare_list.length; index++){
+            var course_info = document.getElementById(dataset[i] + index)
+            var course_div = document.getElementById(`courseContainer-${index}`);
+            if(+course_div.dataset.index > bottom_display + small_screen_amount || +course_div.dataset.index < bottom_display){
+                course_div.classList.add("hidden");
+                course_info.classList.add("hidden");
+            }
+            else{
+                course_div.classList.remove("hidden");
+                course_info.classList.remove("hidden");
+            }
+        }
+    }
+}
+
+function smallScreenDisplay(){
+    if(screen.availWidth < 450 || window.innerWidth < 450){
+        var small_screen_amount = 1
+    }
+    else{
+        var small_screen_amount = 2
+    }
+    if(bottom_display === 0){
+        slide_left.classList.add("hidden");
+    }
+    if(!(slide_left.classList.contains("hidden")) && slide_right.classList.contains("hidden")){
+        course_info_container.classList.add("course-info-left");
+    }
+    if(!(slide_right.classList.contains("hidden")) && slide_left.classList.contains("hidden")){
+        course_info_container.classList.add("course-info-right");
+    }
+    if(!(slide_right.classList.contains("hidden")) && !(slide_left.classList.contains("hidden"))){
+        course_info_container.classList.remove("course-info-right");
+        course_info_container.classList.remove("course-info-left");
+        course_info_container.classList.add("course-info-both");
+    }
+
+
+    for(var i=0; i < 8; i++){
+        for (var index = 0; index < compare_list.length; index ++){
+            var course_info = document.getElementById(dataset[i] + index)
+            var course_div = document.getElementById(`courseContainer-${index}`);
+
+            if(screen.availWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||screen.availWidth <= 768 && +course_div.dataset.index < bottom_display){
+                course_div.classList.add("hidden");
+                course_info.classList.add("hidden");
+            }
+            if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
+                course_div.classList.add("hidden");
+                course_info.classList.add("hidden");
+            }
+            else{
+                course_div.classList.remove("hidden");
+                course_info.classList.remove("hidden");
+            }
+        }
+    }
+}
+
+$(window).on('resize orientationchange load', function(){
+    smallScreenDisplay();
+});

--- a/courses/static/js/manage-bookmarks.js
+++ b/courses/static/js/manage-bookmarks.js
@@ -22,8 +22,10 @@
         loadSelectedCourses: function() {
             if (JSON.parse(localStorage.getItem('comparisonCourses'))) {
                 this.selectedCourses = JSON.parse(localStorage.getItem('comparisonCourses'));
+                this.compareCourses = JSON.parse(localStorage.getItem('compareCourses'));
             } else {
                 this.selectedCourses = [];
+                this.compareCourses = [];
             }
         },
 
@@ -53,8 +55,14 @@
                 if (this.isCourse(course, removedCourse)) {
                     this.selectedCourses.splice(i, 1);
                 }
+                for(var index = 0; index < this.compareCourses.length; index++){
+                    if(this.compareCourses[index].id == removedCourse.courseId){
+                        this.compareCourses.splice(index, 1);
+                    }
+                }
             }
             localStorage.setItem('comparisonCourses', JSON.stringify(this.selectedCourses));
+            localStorage.setItem('compareCourses', JSON.stringify(this.compareCourses));
             location.reload();
         },
 

--- a/courses/static/js/ratings.js
+++ b/courses/static/js/ratings.js
@@ -1,0 +1,116 @@
+function toggle_icon(icon_id){
+            var icon_name = "#" + icon_id;
+            $(icon_name).toggleClass("fa-plus");
+            $(icon_name).toggleClass("fa-minus");
+        }
+
+        function removeCourseCompare(index){
+            compare_list.splice(index, 1);
+            localStorage.setItem('compareCourses', JSON.stringify(compare_list));
+
+            var checkbox = document.getElementById("course" + index);
+            const form = document.getElementById("compareForm");
+            checkbox.checked = false;
+
+            form.submit();
+        }
+
+        window.addEventListener("load", function(){
+            var saved_institutions = JSON.parse(localStorage.getItem("comparisonCourses"));
+            var add_courses_link = document.getElementById("addCoursesLink")
+            var add_courses_button = document.getElementById("addCourses")
+            var id_list = [];
+            var hidden_check = document.getElementById("hiddenCourseCompare");
+
+            for(var i = 0; i < compare_list.length; i++){
+                id_list.push(compare_list[i].id);
+            }
+
+            var index = 0
+            for(var i = 0; i < saved_institutions.length; i++){
+                let courseId = saved_institutions[i].courseId
+                let query = saved_institutions[i].uniId + ',' + courseId + ',' + saved_institutions[i].mode.en
+
+                if(id_list.includes(courseId)){
+                    document.getElementById("hiddenCourseCompare").innerHTML += `<input id="${'course' + index}" type="checkbox" value="${query}" name="courses" hidden checked>`
+                    index++
+                }
+            }
+
+            if(compare_list.length === 7){
+                add_courses_link.href = "";
+                add_courses_button.disabled = true;
+                add_courses_button.style.backgroundColor = "grey";
+            }
+
+            for(var index = 0; index < compare_list.length; index++)
+                for(var i = 1; i <= compare_list[index].rating; i++){
+                    var star = document.getElementById("course-" + index + "-star" + i);
+                    star.innerHTML = "★";
+                    star.classList.add("orange");
+            }
+        });
+
+        function addStarRating(id, value, index){
+            var star = document.getElementById(id);
+
+            if(+value > compare_list[index].rating){
+                for(var i = 1; i <= value; i++){
+                    var star_fill = document.getElementById("course-" + index + "-star" + i);
+                    star_fill.innerHTML = "★";
+                    star_fill.classList.add("orange");
+                }
+                compare_list[index].rating = +value
+            }
+            else if(+value < compare_list[index].rating){
+                for(var i = 3; i > +value; i--){
+                    var star_fill = document.getElementById("course-" + index + "-star" + i);
+                    star_fill.innerHTML = "☆";
+                    star_fill.classList.remove("orange");
+                }
+                compare_list[index].rating = +value
+            }
+            else if(+value == compare_list[index].rating){
+                for(var i = 3; i > +value; i--){
+                    var star_fill = document.getElementById("course-" + index + "-star" + i);
+                    star_fill.innerHTML = "☆";
+                    star_fill.classList.remove("orange");
+                }
+                compare_list[index].rating = +value - 1
+            }
+
+
+            localStorage.setItem('compareCourses', JSON.stringify(compare_list));
+        }
+
+        function hoverStars(value, index, dataIndex){
+
+            if(+value < compare_list[index].rating){
+                for(var i = 3; i > +value; i--){
+                    var star = document.getElementById("course-" + index + "-star" + i);
+                    star.innerHTML = "☆";
+                    star.classList.remove("orange");
+                }
+            }
+            else if(+value > 0){
+                for(var i = 1; i <= value; i++){
+                    var star = document.getElementById("course-" + index + "-star" + i);
+                    star.innerHTML = "★";
+                    star.classList.add("orange");
+                }
+            }
+        }
+
+        function mouseExitStars(index){
+            for(var i = 1; i <= 3; i++){
+            var star = document.getElementById("course-" + index + "-star" + i);
+                if(i <= compare_list[index].rating){
+                    star.innerHTML = "★";
+                    star.classList.add("orange");
+                }
+                else{
+                    star.innerHTML = "☆";
+                    star.classList.remove("orange");
+                }
+            }
+        }

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -18,6 +18,29 @@
     color: black;
     cursor: pointer;
 }
+
+.orange{
+    color: orange;
+}
+
+.course-info-right{
+    margin-right: 49px;
+}
+.course-info-left{
+    margin-left: 49px;
+}
+.course-info-both{
+    margin-right: 27px;
+    margin-left: 27px;
+}
+
+.chevron{
+    font-size: 20px;
+    margin-right: 4px;
+}
+
+#addCourses:hover { color: white; text-decoration: none; }
+
 $course_comparison_line_height: 51px;
 $course_comparison_font_normal: 14px;
 $course_comparison_show_more: 16px;
@@ -69,7 +92,7 @@ $course_comparison_first_column_width: 250px;
             font-size: $course_comparison_font_normal;
             background: #f2f2f2;
             line-height: $course_comparison_line_height;
-            text-align: center;
+            text-align: left;
         }
     }
 }
@@ -136,6 +159,7 @@ $course_comparison_first_column_width: 250px;
         width: 210px;
         height: 40px;
         margin: 48px 16px 6.5px 0px;
+        padding: 9px 26px;
         border: 0px;
         border-radius: 20px;
         background-image: linear-gradient(281deg, #308282, #4ea27d);
@@ -152,6 +176,7 @@ $course_comparison_first_column_width: 250px;
         display: inline-block;
         color: #5d5d5d;
         vertical-align: top;
+        margin-top: 5px;
       }
     }
 
@@ -491,7 +516,9 @@ $course_comparison_first_column_width: 250px;
     font-size:1rem;
 }
 
-
+.hidden{
+    display: none !important;
+}
 
 
 @media only screen and (min-width: 770px) {
@@ -650,6 +677,8 @@ $course_comparison_first_column_width: 250px;
     padding-top:0!important;
 }
 
+
+
 @media only screen and (max-width: 770px) {
     .scrolling-wrapper {
       display: flex;
@@ -681,10 +710,6 @@ $course_comparison_first_column_width: 250px;
         margin-left:auto!important;
         margin-right:auto!important;
     }
-
-    .comparison__top-container-add-btn-compare-text{
-        margin-top: 18px;
-    }
 }
 @media only screen and (min-width: 576px) and (max-width: 766px){
     div.comparison__body, div.course-detail__body{
@@ -701,10 +726,6 @@ $course_comparison_first_column_width: 250px;
         }
         &-add-btn{
             margin-top: 32px;
-
-            &-compare-text{
-                margin-top: 18px;
-            }
         }
     }
 
@@ -766,9 +787,6 @@ $course_comparison_first_column_width: 250px;
         &-add-btn{
             margin-top: 32px;
 
-            &-compare-text{
-                margin-top: 18px;
-            }
         }
     }
 }
@@ -789,7 +807,6 @@ $course_comparison_first_column_width: 250px;
         display: inline-block;
         color: #5d5d5d;
         vertical-align: top;
-        margin-top: 18px;
     }
 
     .comparison .course-detail__course-container-pills-slider{
@@ -820,7 +837,6 @@ $course_comparison_first_column_width: 250px;
             vertical-align: middle;
             flex: 1 1 0;
             font-size: 14px;
-            line-height: $course_comparison_line_height;
             background: #f2f2f2;
 
             &-first {
@@ -843,11 +859,23 @@ $course_comparison_first_column_width: 250px;
         display: flex;
         width: 100%;
         margin-bottom: 4px;
+        align-items: center;
     }
 
     .comparison .course-detail__course-selected{
         min-width: 186px;
         max-width: 186px;
+    }
+
+    .course-info-right{
+        margin-right: 0px;
+    }
+    .course-info-left{
+        margin-left: 0px;
+    }
+    .course-info-both{
+        margin-right: 0px;
+        margin-left: 0px;
     }
 }
 
@@ -868,7 +896,6 @@ $course_comparison_first_column_width: 250px;
         display: inline-block;
         color: #5d5d5d;
         vertical-align: top;
-        margin-top: 18px;
     }
 
     .comparison .course-detail__course-container-pills-slider{
@@ -898,13 +925,12 @@ $course_comparison_first_column_width: 250px;
             vertical-align: middle;
             flex: 1 1 0;
             font-size: 14px;
-            line-height: $course_comparison_line_height;
             background: #f2f2f2;
 
             &-first {
                 color: black;
-                max-width: 186px;
-                min-width: 186px;
+                max-width: 250px;
+                min-width: 250px;
                 text-align: left;
                 line-height: $course_comparison_line_height;
                 flex: 1;
@@ -921,6 +947,18 @@ $course_comparison_first_column_width: 250px;
         display: flex;
         width: 100%;
         margin-bottom: 4px;
+        align-items: center;
+    }
+
+    .course-info-right{
+        margin-right: 0px;
+    }
+    .course-info-left{
+        margin-left: 0px;
+    }
+    .course-info-both{
+        margin-right: 0px;
+        margin-left: 0px;
     }
 }
 

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -39,6 +39,10 @@
     margin-right: 4px;
 }
 
+.blue-text{
+    color: #308282;
+}
+
 #addCourses:hover { color: white; text-decoration: none; }
 
 $course_comparison_line_height: 51px;
@@ -323,7 +327,6 @@ $course_comparison_first_column_width: 250px;
 
         &__course{
             &-container{
-
                 width: 100%;
 
                 &-pills{
@@ -361,6 +364,11 @@ $course_comparison_first_column_width: 250px;
                 background-color: #f2f2f2;
                 margin: 0px 4px 48px 4px;
                 padding: 16px;
+
+                &-exit-course{
+                    float: right;
+                    cursor: pointer;
+                }
             }
 
             &-name{
@@ -768,9 +776,7 @@ $course_comparison_first_column_width: 250px;
     .comparison .course-detail__course-container{
         display: block;
         &-pills-slider{
-            display: flex;
-            align-items: center;
-            justify-content:center;
+            display: none;
         }
     }
     .comparison .course-detail__course-selected{
@@ -786,7 +792,6 @@ $course_comparison_first_column_width: 250px;
         }
         &-add-btn{
             margin-top: 32px;
-
         }
     }
 }

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -658,13 +658,13 @@ $course_comparison_first_column_width: 250px;
 
 
 
-@media only screen and (max-width: 575px){
+@media(max-width: 575px){
     div.comparison__body, div.course-detail__body{
         margin-left:auto!important;
         margin-right:auto!important;
     }
 }
-@media only screen and (min-width: 576px) and (max-width: 766px){
+@media(min-width: 576px){
     div.comparison__body, div.course-detail__body{
         width: 540px!important;
         margin-left:auto!important;
@@ -683,7 +683,7 @@ $course_comparison_first_column_width: 250px;
         }
     }
 }
-@media (min-width: 767px), (max-width: 991px){
+@media (min-width: 767px){
     div.comparison__body, div.course-detail__body{
         width: 720px!important;
         margin-left:auto!important;
@@ -744,7 +744,7 @@ $course_comparison_first_column_width: 250px;
         }
     }
 }
-@media only screen and (min-width: 992px) and (max-width: 1199px){
+@media (min-width: 992px){
     div.comparison__body, div.course-detail__body{
         width: 960px!important;
         margin-left:auto!important;
@@ -752,7 +752,7 @@ $course_comparison_first_column_width: 250px;
     }
 }
 
-@media only screen and (min-width: 1200px){
+@media (min-width: 1200px){
     div.comparison__body, div.course-detail__body{
         width: 1140px!important;
         margin-left:auto!important;

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -103,6 +103,7 @@ $course_comparison_first_column_width: 250px;
 .small-flex-div{
     display: flex;
     flex-direction: row;
+    margin-left: auto;
 }
 
 .single-arrow{
@@ -332,6 +333,7 @@ $course_comparison_first_column_width: 250px;
                 &-pills{
                     display: flex;
                     overflow: hidden;
+                    flex: 1;
 
                     &-slider{
                         display: flex;
@@ -825,6 +827,7 @@ $course_comparison_first_column_width: 250px;
             color: black;
             min-height: 44px;
             margin-bottom: 8px;
+            margin-left: auto;
 
             &-header {
                 height: $course_comparison_line_height;
@@ -843,6 +846,7 @@ $course_comparison_first_column_width: 250px;
             flex: 1 1 0;
             font-size: 14px;
             background: #f2f2f2;
+            margin-left: auto;
 
             &-first {
                 color: black;
@@ -865,6 +869,8 @@ $course_comparison_first_column_width: 250px;
         width: 100%;
         margin-bottom: 4px;
         align-items: center;
+        margin-left: auto;
+
     }
 
     .comparison .course-detail__course-selected{
@@ -953,6 +959,7 @@ $course_comparison_first_column_width: 250px;
         width: 100%;
         margin-bottom: 4px;
         align-items: center;
+        flex: 1;
     }
 
     .course-info-right{

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -291,10 +291,12 @@ $course_comparison_first_column_width: 250px;
             &-container{
                 display: flex;
                 flex-direction: row; 
-                justify-content: center; 
-
+                justify-content: center;
                 width: 100%;
 
+                &-pills{
+                    display: flex;
+                }
             }
             &-selected{
                 color: black; 
@@ -684,7 +686,21 @@ $course_comparison_first_column_width: 250px;
         margin-left:auto!important;
         margin-right:auto!important;
     }
+    .comparison .course-detail__course-container{
+        display: block;
+        &-pills-slider{
+            background-color: #d2d2d2;
+            color: black;
+            width: 49px;
+            margin-bottom: 48px;
 
+        }
+    }
+    .comparison .course-detail__course-selected{
+        display: block;
+        width: 100%;
+        margin-bottom: 17px;
+    }
     .comparison__top-container{
         &-need-help-box{
             display: block;

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -36,9 +36,9 @@ $course_comparison_first_column_width: 250px;
   &__row {
     display: flex;
     color: black;
-    background: #f2f2f2;
+
     min-height: 44px;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
 
     &-header {
       color: black;
@@ -60,6 +60,7 @@ $course_comparison_first_column_width: 250px;
     flex: 1 1 0;
     font-size: 14px;
     line-height: $course_comparison_line_height;
+    background: #f2f2f2;
 
 
     &-first {
@@ -73,6 +74,7 @@ $course_comparison_first_column_width: 250px;
       padding-left: 10px;
       display: inline-block;
       font-size: $course_comparison_font_normal;
+      background: #f2f2f2;
     }
   }
 }
@@ -303,7 +305,7 @@ $course_comparison_first_column_width: 250px;
                 margin-bottom: auto;
                 margin-top: 17px;
                 margin-right: auto; 
-                width: 250px;
+                min-width: 250px;
             }
         }
 
@@ -669,6 +671,7 @@ $course_comparison_first_column_width: 250px;
         margin-right:auto!important;
     }
 
+
     .comparison__top-container{
         &-need-help-box{
             display: block;
@@ -680,19 +683,48 @@ $course_comparison_first_column_width: 250px;
         }
     }
 }
-@media only screen and (min-width: 767px) and (max-width: 991px){
+@media (min-width: 767px), (max-width: 991px){
     div.comparison__body, div.course-detail__body{
         width: 720px!important;
         margin-left:auto!important;
         margin-right:auto!important;
     }
+    .course_comparison-table__row{
+        display: block;
+        text-align: center;
+        margin-bottom: 16px;
+
+        &-header{
+            margin-bottom: 16px;
+        }
+    }
+    .course_comparison-table__column-first{
+        display: block;
+        min-width: 100%;
+        max-width: 100%;
+        margin-bottom: 4px;
+    }
+
+    .small-flex-div{
+        display: flex;
+        flex-direction: row;
+    }
+
     .comparison .course-detail__course-container{
         display: block;
         &-pills-slider{
-            background-color: #d2d2d2;
-            color: black;
-            width: 49px;
+            display: flex;
+            align-items: center;
+            justify-content:center;
             margin-bottom: 48px;
+            width: 49px;
+            background-color: #d2d2d2;
+
+            &-arrow{
+                color: black;
+                font-size: 20px;
+                font-weight: bold;
+            }
 
         }
     }

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -24,59 +24,66 @@ $course_comparison_show_more: 16px;
 $course_comparison_first_column_width: 250px;
 
 .course_comparison-table {
-  &__tick-icon {
-    font-size: 28px;
-    background: -webkit-gradient(linear, left top, left bottom, from(#4EA27D), to(#308282));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    display: initial;
-    vertical-align: middle;
-  }
+    &__tick-icon {
+        font-size: 28px;
+        background: -webkit-gradient(linear, left top, left bottom, from(#4EA27D), to(#308282));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        display: initial;
+        vertical-align: middle;
+}
+    &__row{
+        display: block;
+        text-align: center;
+        margin-bottom: 16px;
+        min-height: 44px;
 
-  &__row {
+            &-header{
+                height: $course_comparison_line_height;
+                line-height: $course_comparison_line_height;
+                margin-bottom: 16px;
+                display: block;
+                background: #f2f2f2;
+                color: black;
+                padding-left: 10px;
+            }
+        }
+
+
+    &__column{
+        text-align: center;
+        vertical-align: middle;
+        flex: 1 1 0;
+        font-size: 14px;
+        line-height: $course_comparison_line_height;
+        background: #f2f2f2;
+        color: black;
+
+        &-first{
+            display: block;
+            min-width: 100%;
+            max-width: 100%;
+            margin-bottom: 4px;
+            color: black;
+            padding-left: 10px;
+            font-size: $course_comparison_font_normal;
+            background: #f2f2f2;
+            line-height: $course_comparison_line_height;
+            text-align: center;
+        }
+    }
+}
+.small-flex-div{
     display: flex;
-    color: black;
+    flex-direction: row;
+}
 
-    min-height: 44px;
-    margin-bottom: 8px;
+.single-arrow{
+    width: 49px;
+}
 
-    &-header {
-      color: black;
-      background: #f2f2f2;
-      height: $course_comparison_line_height;
-      line-height: $course_comparison_line_height;
-      margin-bottom: 10px;
-      text-align: left;
-      display: block;
-      padding-left: 10px;
-      font-weight: normal;
-      font-size: 20px;
-    }
-  }
-
-  &__column {
-    text-align: center;
-    vertical-align: middle;
-    flex: 1 1 0;
-    font-size: 14px;
-    line-height: $course_comparison_line_height;
-    background: #f2f2f2;
-
-
-    &-first {
-      color: black;
-      max-width: $course_comparison_first_column_width;
-      min-width: $course_comparison_first_column_width;
-      text-align: left;
-      line-height: $course_comparison_line_height;
-      flex: 1;
-      vertical-align: middle;
-      padding-left: 10px;
-      display: inline-block;
-      font-size: $course_comparison_font_normal;
-      background: #f2f2f2;
-    }
-  }
+.both-arrows{
+    width: 27px;
 }
 
 .comparison {
@@ -145,7 +152,6 @@ $course_comparison_first_column_width: 250px;
         display: inline-block;
         color: #5d5d5d;
         vertical-align: top;
-        margin-top: 18px;
       }
     }
 
@@ -156,6 +162,7 @@ $course_comparison_first_column_width: 250px;
       float: right;
       padding: 20px;
       text-align: center;
+      margin-bottom: 31px;
     }
   }
 
@@ -291,13 +298,27 @@ $course_comparison_first_column_width: 250px;
 
         &__course{
             &-container{
-                display: flex;
-                flex-direction: row; 
-                justify-content: center;
+
                 width: 100%;
 
                 &-pills{
                     display: flex;
+                    overflow: hidden;
+
+                    &-slider{
+                        display: flex;
+                        align-items: center;
+                        justify-content:center;
+                        margin-bottom: 48px;
+                        background-color: #d2d2d2;
+                        cursor: pointer;
+
+                        &-arrow{
+                            color: black;
+                            font-size: 20px;
+                            font-weight: bold;
+                        }
+                    }
                 }
             }
             &-selected{
@@ -655,13 +676,14 @@ $course_comparison_first_column_width: 250px;
     
   }
 
-
-
-
 @media only screen and (max-width: 575px){
     div.comparison__body, div.course-detail__body{
         margin-left:auto!important;
         margin-right:auto!important;
+    }
+
+    .comparison__top-container-add-btn-compare-text{
+        margin-top: 18px;
     }
 }
 @media only screen and (min-width: 576px) and (max-width: 766px){
@@ -671,7 +693,6 @@ $course_comparison_first_column_width: 250px;
         margin-right:auto!important;
     }
 
-
     .comparison__top-container{
         &-need-help-box{
             display: block;
@@ -680,6 +701,19 @@ $course_comparison_first_column_width: 250px;
         }
         &-add-btn{
             margin-top: 32px;
+
+            &-compare-text{
+                margin-top: 18px;
+            }
+        }
+    }
+
+    .comparison .course-detail__course-container{
+        display: block;
+        &-pills-slider{
+            display: flex;
+            align-items: center;
+            justify-content:center;
         }
     }
 }
@@ -716,16 +750,6 @@ $course_comparison_first_column_width: 250px;
             display: flex;
             align-items: center;
             justify-content:center;
-            margin-bottom: 48px;
-            width: 49px;
-            background-color: #d2d2d2;
-
-            &-arrow{
-                color: black;
-                font-size: 20px;
-                font-weight: bold;
-            }
-
         }
     }
     .comparison .course-detail__course-selected{
@@ -741,6 +765,10 @@ $course_comparison_first_column_width: 250px;
         }
         &-add-btn{
             margin-top: 32px;
+
+            &-compare-text{
+                margin-top: 18px;
+            }
         }
     }
 }
@@ -750,6 +778,77 @@ $course_comparison_first_column_width: 250px;
         margin-left:auto!important;
         margin-right:auto!important;
     }
+
+    .course-detail__course-container{
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+    }
+
+    .comparison__top-container-add-btn-compare-text {
+        display: inline-block;
+        color: #5d5d5d;
+        vertical-align: top;
+        margin-top: 18px;
+    }
+
+    .comparison .course-detail__course-container-pills-slider{
+       display: none;
+    }
+
+    .course_comparison-table {
+        &__row {
+            display: flex;
+            flex-direction: row;
+            color: black;
+            min-height: 44px;
+            margin-bottom: 8px;
+
+            &-header {
+                height: $course_comparison_line_height;
+                line-height: $course_comparison_line_height;
+                margin-bottom: 10px;
+                display: block;
+                background: #f2f2f2;
+                color: black;
+                padding-left: 10px;
+            }
+        }
+
+        &__column {
+            text-align: center;
+            vertical-align: middle;
+            flex: 1 1 0;
+            font-size: 14px;
+            line-height: $course_comparison_line_height;
+            background: #f2f2f2;
+
+            &-first {
+                color: black;
+                max-width: 186px;
+                min-width: 186px;
+                text-align: left;
+                line-height: $course_comparison_line_height;
+                flex: 1;
+                vertical-align: middle;
+                padding-left: 10px;
+                display: inline-block;
+                font-size: $course_comparison_font_normal;
+                background: #f2f2f2;
+            }
+        }
+    }
+
+    .small-flex-div{
+        display: flex;
+        width: 100%;
+        margin-bottom: 4px;
+    }
+
+    .comparison .course-detail__course-selected{
+        min-width: 186px;
+        max-width: 186px;
+    }
 }
 
 @media only screen and (min-width: 1200px){
@@ -757,6 +856,71 @@ $course_comparison_first_column_width: 250px;
         width: 1140px!important;
         margin-left:auto!important;
         margin-right:auto!important;
+    }
+
+    .course-detail__course-container{
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+    }
+
+    .comparison__top-container-add-btn-compare-text {
+        display: inline-block;
+        color: #5d5d5d;
+        vertical-align: top;
+        margin-top: 18px;
+    }
+
+    .comparison .course-detail__course-container-pills-slider{
+       display: none;
+    }
+    .course_comparison-table {
+        &__row {
+            display: flex;
+            flex-direction: row;
+            color: black;
+            min-height: 44px;
+            margin-bottom: 8px;
+
+            &-header {
+                height: $course_comparison_line_height;
+                line-height: $course_comparison_line_height;
+                margin-bottom: 10px;
+                display: block;
+                background: #f2f2f2;
+                color: black;
+                padding-left: 10px;
+            }
+        }
+
+        &__column {
+            text-align: center;
+            vertical-align: middle;
+            flex: 1 1 0;
+            font-size: 14px;
+            line-height: $course_comparison_line_height;
+            background: #f2f2f2;
+
+            &-first {
+                color: black;
+                max-width: 186px;
+                min-width: 186px;
+                text-align: left;
+                line-height: $course_comparison_line_height;
+                flex: 1;
+                vertical-align: middle;
+                padding-left: 10px;
+                display: inline-block;
+                font-size: $course_comparison_font_normal;
+                background: #f2f2f2;
+            }
+        }
+    }
+
+    .small-flex-div{
+        display: flex;
+        width: 100%;
+        margin-bottom: 4px;
     }
 }
 

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -658,13 +658,13 @@ $course_comparison_first_column_width: 250px;
 
 
 
-@media(max-width: 575px){
+@media only screen and (max-width: 575px){
     div.comparison__body, div.course-detail__body{
         margin-left:auto!important;
         margin-right:auto!important;
     }
 }
-@media(min-width: 576px){
+@media only screen and (min-width: 576px) and (max-width: 766px){
     div.comparison__body, div.course-detail__body{
         width: 540px!important;
         margin-left:auto!important;
@@ -683,7 +683,7 @@ $course_comparison_first_column_width: 250px;
         }
     }
 }
-@media (min-width: 767px){
+@media only screen and (min-width: 767px) and (max-width: 991px){
     div.comparison__body, div.course-detail__body{
         width: 720px!important;
         margin-left:auto!important;
@@ -744,7 +744,7 @@ $course_comparison_first_column_width: 250px;
         }
     }
 }
-@media (min-width: 992px){
+@media only screen and (min-width: 992px) and  (max-width: 1199px){
     div.comparison__body, div.course-detail__body{
         width: 960px!important;
         margin-left:auto!important;
@@ -752,7 +752,7 @@ $course_comparison_first_column_width: 250px;
     }
 }
 
-@media (min-width: 1200px){
+@media only screen and (min-width: 1200px){
     div.comparison__body, div.course-detail__body{
         width: 1140px!important;
         margin-left:auto!important;

--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -1,21 +1,23 @@
 @import '../../../CMS/static/scss/fonts';
 @import '../../../CMS/static/scss/variables';
 @import '../../../CMS/static/scss/partials/forms';
-
-.comparison__xs-rotate {
-  // background-color: #1F283A;
-  color: #1F283A;
-
-  h3 {
+.comparison__xs-rotate{
+    // background-color: #1F283A;
     color: #1F283A;
-    font-family: "Nunito Sans", sans-serif;
-  }
+    h3{
+        color: #1F283A;
+        font-family: "Nunito Sans", sans-serif;
+    }
+}
+.course-detail__headline_stat{
+    display: none;
 }
 
-.course-detail__headline_stat {
-  display: none;
+.rating{
+    display: inline-block;
+    color: black;
+    cursor: pointer;
 }
-
 $course_comparison_line_height: 51px;
 $course_comparison_font_normal: 14px;
 $course_comparison_show_more: 16px;
@@ -208,532 +210,505 @@ $course_comparison_first_column_width: 250px;
     margin-bottom: 48px;
   }
 
-  &__courses {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-  }
-
-  &__course {
-    margin: 0px 4px;
-
-    &-columns {
-      display: flex;
-      width: 100%;
+    &__courses {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
     }
-
-    &-column {
-      width: 50%;
-
-      &:first-child {
-        border-right: 1px solid $gradient-dark-green;
-
-        .comparison__course {
-          margin-left: 0px;
-        }
-      }
-
-      &:last-child {
-        .comparison__course {
-          margin-right: 0px;
-        }
-      }
-    }
-
-    &-selector {
-      @include custom-selector();
-
-      width: 100%;
-
-      .select-selected {
-        @include small-font-mixin();
-
-        padding: 13px 11px;
-
-        &:after {
-          top: 16px;
-          right: 13px;
-        }
-
-        &.select-arrow-active {
-          @include green-gradient-background-mixin();
-
-          &:after {
-            top: 8px;
-            border-color: transparent transparent $white transparent;
-          }
-        }
-      }
-
-      .select-items {
-        // width: calc(100vw - 60px);
-      }
-
-      &#course2 {
-        .select-items {
-          left: initial;
-        }
-      }
-    }
-  }
-
-  &__subject-heading {
-    @include xs-heading--bold-mixin();
-
-    color: $ux-grey-3;
-  }
-
-
-  .course-detail {
 
     &__course {
-      &-container {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
+        margin: 0px 4px;
 
-        width: 100%;
-
-      }
-
-      &-selected {
-        color: black;
-        margin-bottom: auto;
-        margin-top: 17px;
-        margin-right: auto;
-        width: $course_comparison_first_column_width
-      }
-    }
-
-    &__courses {
-      &-container {
-        flex: 1;
-        background-color: #f2f2f2;
-        margin: 0px 4px 48px 4px;
-        padding: 16px;
-      }
-
-      &-name {
-        margin: 16px 0;
-        font-family: "Nunito Sans", sans-serif;
-        font-size: 18px;
-        color: #1e1e1e;
-        line-height: 1.2;
-      }
-
-      &-institution-name {
-        margin: 16px 0 0;
-        font-family: "Nunito Sans", sans-serif;
-        font-size: 16px;
-        color: #595959
-      }
-    }
-
-    &__compare-btn {
-      display: none;
-    }
-
-
-    .course-detail__lead {
-
-      .course-detail__institution-info {
-        .course-detail__institution-name {
-          @include desktop-body-font--bold-mixin();
-
-          color: $link-blue;
+        &-columns {
+            display: flex;
+            width: 100%;
         }
-      }
-    }
 
-    .course-detail__body {
-      padding: 0px;
+        &-column {
+            width: 50%;
 
-      .course-detail__accordion-block {
-        .course-detail__accordion {
-          margin-left: auto;
-          margin-right: auto;
-          // width: 98vw;
+            &:first-child {
+                border-right: 1px solid $gradient-dark-green;
 
-          .course-detail__accordion-heading {
-          }
-
-          .course-detail__accordion-body {
-
-            .satisfaction_subject_name {
-              font-size: $s-heading-font-size;
-            }
-
-            .student-satisfaction__block {
-              padding: 0px;
-
-              .student-satisfaction__data-group {
-                margin-left: -30px;
-                margin-right: -30px;
-
-                .student-satisfaction__charts {
-                  // padding-left: 30px;
-                  // padding-right: 30px;
-
-                  .student-satisfaction__chart-wrapper {
-                    width: 100%;
-
-                    .student-satisfaction__chart {
-                      padding: 0px;
-                    }
-                  }
+                .comparison__course  {
+                    margin-left: 0px;
                 }
-              }
             }
 
-            .after-course__block, .accreditation__block, .after-course__lead-block {
-              padding: 0;
+            &:last-child {
+                .comparison__course  {
+                    margin-right: 0px;
+                }
             }
-
-          }
         }
-      }
+
+        &-selector {
+            @include custom-selector();
+
+            width: 100%;
+
+            .select-selected {
+                @include small-font-mixin();
+
+                padding: 13px 11px;
+
+                &:after {
+                    top: 16px;
+                    right: 13px;
+                }
+
+                &.select-arrow-active {
+                    @include green-gradient-background-mixin();
+
+                    &:after {
+                        top: 8px;
+                        border-color: transparent transparent $white transparent;
+                    }
+                }
+            }
+
+            .select-items {
+                // width: calc(100vw - 60px);
+            }
+
+            &#course2 {
+                .select-items {
+                    left: initial;
+                }
+            }
+        }
     }
-  }
 
-  .student-satisfaction__overview {
-    .student-satisfaction__overview-lead {
-      font-size: 2rem !important;
+    &__subject-heading {
+        @include xs-heading--bold-mixin();
+
+        color: $ux-grey-3;
     }
-  }
 
-  .student-satisfaction__data-group-heading {
-    font-size: 1.1rem !important;
-  }
+    .course-detail {
 
-  .entry-information__chart-label {
-    font-size: 0.8rem !important;
-  }
+        &__course{
+            &-container{
+                display: flex;
+                flex-direction: row; 
+                justify-content: center; 
 
-  .entry-information__overview-lead {
-    font-size: 1.2rem !important;
-  }
+                width: 100%;
 
-  .entry-information__heading {
-    font-size: 1.1rem !important;
-  }
+            }
+            &-selected{
+                color: black; 
+                margin-bottom: auto;
+                margin-top: 17px;
+                margin-right: auto; 
+                width: 250px;
+            }
+        }
 
-  .entry-information__chart-label {
-    font-size: 0.8rem !important;
-  }
+        &__courses{
+            &-container{
+                flex: 1;
+                background-color: #f2f2f2;
+                margin: 0px 4px 48px 4px;
+                padding: 16px;
+            }
 
-  .one-year__overview-lead {
-    font-size: 2rem !important;
-  }
+            &-name{
+                margin: 16px 0;
+                font-family: "Nunito Sans", sans-serif;
+                font-size: 18px;
+                color: #1e1e1e;
+                line-height: 1.2;
+            }
 
-  .one-year__overview-sublead {
-    font-size: 1.1rem !important;
-  }
+            &-institution-name{
+                margin: 16px 0 0;
+                font-family: "Nunito Sans", sans-serif;
+                font-size: 16px;
+                color: #595959
+            }
+        }
 
-  .one-year__heading {
-    font-size: 1.1rem !important;
-  }
+        &__compare-btn {
+            display: none;
+        }
 
-  .one-year-block__chart-label {
-    font-size: 0.8rem !important;
-  }
+        .course-detail__lead {
 
-  .accreditation__overview-lead {
-    font-size: 1.2rem !important;
-  }
+            .course-detail__institution-info {
+                .course-detail__institution-name {
+                    @include desktop-body-font--bold-mixin();
 
-  .earnings-after-course_block .earnings-after-course__stats-heading .rich-text p {
-    font-size: 1.1rem !important;
-  }
+                    color: $link-blue;
+                }
+            }
+        }
 
-  .earnings-after-course_block .earnings-after-course_explanation-text .rich-text p {
-    font-size: 1rem !important;
-  }
+        .course-detail__body {
+            padding: 0px;
 
-  .earnings-after-course_block .earnings-after-course_section-block h3 {
-    font-size: 1.1rem !important;
-  }
+            .course-detail__accordion-block {
+                .course-detail__accordion {
+                    margin-left: auto;
+                    margin-right: auto;
+                    // width: 98vw;
 
-  .employment-after-course__data-point-overview .employment-after-course__data-point-overview-lead {
-    font-size: 2rem !important;
-  }
+                    .course-detail__accordion-heading {
+                    }
 
-  .employment-after-course__data-point-overview p {
-    font-size: 1rem !important;
-  }
+                    .course-detail__accordion-body {
+                       
+                        .satisfaction_subject_name {
+                            font-size: $s-heading-font-size;
+                        }
 
-  .employment-after-course__block .employment-after-course__stats-heading {
-    font-size: 1.1rem !important;
-  }
+                        .student-satisfaction__block {
+                            padding: 0px;
 
-  .employment-after-course__block .employment-after-course__data-point .employment-after-course__chart-block .employment-after-course__chart .employment-after-course__chart-label {
-    font-size: 0.8rem !important;
-  }
+                            .student-satisfaction__data-group {
+                                margin-left: -30px;
+                                margin-right: -30px;
 
-  .entry-information__chart-label {
-    text-align: left;
-  }
+                                .student-satisfaction__charts {
+                                    // padding-left: 30px;
+                                    // padding-right: 30px;
 
-  .employment-after-course__stats-heading {
-    font-size: 1.1rem !important;
-  }
+                                    .student-satisfaction__chart-wrapper {
+                                        width: 100%;
+
+                                        .student-satisfaction__chart {
+                                            padding: 0px;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        .after-course__block, .accreditation__block, .after-course__lead-block {
+                            padding: 0;
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+   
+    .student-satisfaction__overview{
+        .student-satisfaction__overview-lead{
+            font-size:2rem!important;
+        }
+    }
+    .student-satisfaction__data-group-heading{
+        font-size:  1.1rem!important;
+    }
+    .entry-information__chart-label{
+        font-size:0.8rem!important;
+    }
+    .entry-information__overview-lead{
+        font-size:1.2rem!important;
+    }
+    .entry-information__heading{
+        font-size:1.1rem!important;
+    }
+    .entry-information__chart-label{
+        font-size:0.8rem!important;
+    }
+    .one-year__overview-lead{
+        font-size:2rem!important;
+    }
+    .one-year__overview-sublead{
+        font-size:1.1rem!important;
+    }
+    .one-year__heading{
+        font-size:1.1rem!important;
+    }
+    .one-year-block__chart-label{
+        font-size:0.8rem!important;
+    }
+    .accreditation__overview-lead{
+        font-size:1.2rem!important;
+    }
+    .earnings-after-course_block .earnings-after-course__stats-heading .rich-text p{
+        font-size:1.1rem!important;
+    }
+    .earnings-after-course_block .earnings-after-course_explanation-text .rich-text p {
+        font-size:1rem!important;
+    }
+    .earnings-after-course_block .earnings-after-course_section-block h3 {
+        font-size:1.1rem!important;
+    }
+    .employment-after-course__data-point-overview .employment-after-course__data-point-overview-lead {
+        font-size:2rem!important;
+    }
+    .employment-after-course__data-point-overview p {
+        font-size:1rem!important;
+    }
+    .employment-after-course__block .employment-after-course__stats-heading{
+        font-size:1.1rem!important;
+    }
+    .employment-after-course__block .employment-after-course__data-point .employment-after-course__chart-block .employment-after-course__chart .employment-after-course__chart-label{
+        font-size:0.8rem!important;
+    }
+    .entry-information__chart-label{
+        text-align: left;
+    }
+    .employment-after-course__stats-heading{
+        font-size:1.1rem!important;
+    }
 }
 
 
 .course-detail .course-detail__lead .course-detail__course-name {
-  font-size: 1rem;
+    font-size: 1rem;
+}
+.course-detail .course-detail__lead a.course-detail__institution-name {
+    font-size:1rem;
 }
 
-.course-detail .course-detail__lead a.course-detail__institution-name {
-  font-size: 1rem;
-}
+
 
 
 @media only screen and (min-width: 770px) {
-  .comparison__header-bg-icon {
-    padding-top: 15px;
-    height: 150px;
-    width: auto;
-  }
-  .comparison {
-    padding: 35px 30px 55px;
-
-    &__overview {
-      h1 {
-        font-size: 1.75rem;
-        color: white;
-      }
-
+    .comparison__header-bg-icon{
+        padding-top:15px;
+        height:150px;
+        width:auto;
     }
+    .comparison {
+        padding: 35px 30px 55px;
 
-    &__course {
-      margin: 0px 20px;
-
-      &-count {
-        @include l-heading--bold-mixin();
-
-        color: $gradient-light-green;
-      }
-
-      &-selector {
-        .select-items {
-          max-width: 1020px;
+        &__overview {
+            h1{
+                font-size:1.75rem;
+                color:white;
+            }
+            
         }
-      }
+        &__course {
+            margin: 0px 20px;
 
-    }
+            &-count {
+                @include l-heading--bold-mixin();
 
-    &__lead {
-      @include s-heading-mixin();
+                color: $gradient-light-green;
+            }
 
-      color: $ux-grey-3;
-    }
-
-    &__nav-box {
-      .rich-text {
-        p {
-          @include desktop-body-font-mixin();
+            &-selector {
+                .select-items {
+                    max-width: 1020px;
+                }
+            }
+            
         }
-      }
-    }
 
-    &__heading {
-      font-size: 1.5rem;
-      text-align: left;
-      color: $black;
-      font-weight: normal;
-      font-stretch: normal;
-      font-style: normal;
-      line-height: normal;
-      letter-spacing: normal;
-    }
-
-    &__subject-heading {
-      @include s-heading--bold-mixin();
-
-      color: $ux-grey-3;
-    }
-
-    .course-detail {
-      .course-detail__lead {
-        .course-detail__institution-info {
-          padding: 26px 30px 28px;
-
-          background-color: $divider-grey;
-
-          .course-detail__institution-name {
+        &__lead {
             @include s-heading-mixin();
 
-
-            color: $link-blue;
-          }
-
-          .course-detail__institution-locations {
-            @include small-font-mixin();
-
-            margin: 8px 0 0;
-          }
+            color: $ux-grey-3;
         }
 
-        .course-detail__course-overview {
-          display: flex;
-          flex-wrap: wrap;
-          justify-content: space-evenly;
+        &__nav-box {
+            .rich-text {
+                p {
+                    @include desktop-body-font-mixin();
+                }
+            }
+        }
 
-          margin: 20px 0px 35px;
-
-          .course-detail__overview-item {
-
-            display: flex;
-            flex-direction: column;
-            justify-content: left;
-            align-items: left;
-            width: 114px;
+        &__heading {
+            font-size:1.5rem;
             text-align: left;
-
-            .course-detail__overview-item-heading {
-              @include small-font--bold-mixin();
-              margin: 0px;
-              margin-bottom: 5px;
-            }
-
-            .course-detail__overview-item-value {
-              @include small-font--bold-mixin();
-              margin: 0px;
-
-              color: $helper-grey;
-            }
-          }
+            color: $black;
+            font-weight: normal;
+            font-stretch: normal;
+            font-style: normal;
+            line-height: normal;
+            letter-spacing: normal;     
         }
-      }
 
-      .course-detail__body {
-        width: 100%;
+        &__subject-heading {
+            @include s-heading--bold-mixin();
 
-        .course-detail__accordion-block {
-          .course-detail__accordion {
-            width: 100%;
-            margin-left: 0px;
-            margin-right: 0px;
+            color: $ux-grey-3;
+        }
 
-            .course-detail__accordion-body {
-              .student-satisfaction__block {
-                padding: 0px;
+        .course-detail  {
+            .course-detail__lead {
+                .course-detail__institution-info {
+                    padding: 26px 30px 28px;
 
-                .comparison__course {
-                  display: flex;
-                  flex-wrap: wrap;
+                    background-color: $divider-grey;
 
-                }
+                    .course-detail__institution-name {
+                        @include s-heading-mixin();
 
-                .student-satisfaction__data-group {
-                  .student-satisfaction__charts {
-                    .student-satisfaction__chart-wrapper {
-                      // width: 50%;
+
+                        color: $link-blue;
                     }
-                  }
+
+                    .course-detail__institution-locations {
+                        @include small-font-mixin();
+
+                        margin: 8px 0 0;
+                    }
                 }
-              }
+
+                .course-detail__course-overview {
+                    display: flex;
+                    flex-wrap: wrap;
+                    justify-content: space-evenly;
+
+                    margin: 20px 0px 35px;
+
+                    .course-detail__overview-item {
+
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: left;
+                        align-items: left;
+                        width: 114px;
+                        text-align: left;
+
+                        .course-detail__overview-item-heading {
+                            @include small-font--bold-mixin();
+                            margin: 0px;
+                            margin-bottom: 5px;
+                        }
+
+                        .course-detail__overview-item-value {
+                            @include small-font--bold-mixin();
+                            margin: 0px;
+
+                            color: $helper-grey;
+                        }
+                    }
+                }
             }
-          }
+
+            .course-detail__body {
+                width: 100%;
+
+                .course-detail__accordion-block {
+                    .course-detail__accordion {
+                        width: 100%;
+                        margin-left: 0px;
+                        margin-right: 0px;
+
+                        .course-detail__accordion-body {
+                            .student-satisfaction__block {
+                                padding: 0px;
+
+                                .comparison__course {
+                                    display: flex;
+                                    flex-wrap: wrap;
+                                    
+                                }
+
+                                .student-satisfaction__data-group {
+                                    .student-satisfaction__charts {
+                                        .student-satisfaction__chart-wrapper {
+                                            // width: 50%;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
 }
-
-.student-satisfaction__block .student-satisfaction__data-group .student-satisfaction__data-group-heading {
-  padding-top: 0 !important;
+.student-satisfaction__block .student-satisfaction__data-group .student-satisfaction__data-group-heading{
+    padding-top:0!important;
 }
 
 @media only screen and (max-width: 770px) {
-  .scrolling-wrapper {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-
-    .student-satisfaction__data-group {
-      flex: 0 0 85vw;
+    .scrolling-wrapper {
+      display: flex;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    
+      .student-satisfaction__data-group {
+        flex: 0 0 85vw;
+      }
+  
+      .student-satisfaction__data-group:last-child{
+        margin-right:10px
+      }
+      .student-satisfaction__data-group:first-child{
+        margin-left:10px
+      }
     }
-
-    .student-satisfaction__data-group:last-child {
-      margin-right: 10px
+    .scrolling-wrapper {
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
-
-    .student-satisfaction__data-group:first-child {
-      margin-left: 10px
-    }
+    
   }
-  .scrolling-wrapper {
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
 
+
+
+
+@media only screen and (max-width: 575px){
+    div.comparison__body, div.course-detail__body{
+        margin-left:auto!important;
+        margin-right:auto!important;
+    }
+}
+@media only screen and (min-width: 576px) and (max-width: 766px){
+    div.comparison__body, div.course-detail__body{
+        width: 540px!important;
+        margin-left:auto!important;
+        margin-right:auto!important;
+    }
+
+    .comparison__top-container{
+        &-need-help-box{
+            display: block;
+            width: 100%;
+            margin: auto;
+        }
+        &-add-btn{
+            margin-top: 32px;
+        }
+    }
+}
+@media only screen and (min-width: 767px) and (max-width: 991px){
+    div.comparison__body, div.course-detail__body{
+        width: 720px!important;
+        margin-left:auto!important;
+        margin-right:auto!important;
+    }
+
+    .comparison__top-container{
+        &-need-help-box{
+            display: block;
+            width: 100%;
+            margin: auto;
+        }
+        &-add-btn{
+            margin-top: 32px;
+        }
+    }
+}
+@media only screen and (min-width: 992px) and (max-width: 1199px){
+    div.comparison__body, div.course-detail__body{
+        width: 960px!important;
+        margin-left:auto!important;
+        margin-right:auto!important;
+    }
 }
 
-
-@media only screen and (max-width: 575px) {
-  div.comparison__body, div.course-detail__body {
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-}
-
-@media only screen and (min-width: 576px) and (max-width: 766px) {
-  div.comparison__body, div.course-detail__body {
-    width: 540px !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-
-  .comparison__top-container {
-    &-need-help-box {
-      display: block;
-      width: 100%;
-      margin: auto;
+@media only screen and (min-width: 1200px){
+    div.comparison__body, div.course-detail__body{
+        width: 1140px!important;
+        margin-left:auto!important;
+        margin-right:auto!important;
     }
-
-    &-add-btn {
-      margin-top: 32px;
-    }
-  }
-}
-
-@media only screen and (min-width: 767px) and (max-width: 991px) {
-  div.comparison__body, div.course-detail__body {
-    width: 720px !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-
-  .comparison__top-container {
-    &-need-help-box {
-      display: block;
-      width: 100%;
-      margin: auto;
-    }
-
-    &-add-btn {
-      margin-top: 32px;
-    }
-  }
-}
-
-@media only screen and (min-width: 992px) and (max-width: 1199px) {
-  div.comparison__body, div.course-detail__body {
-    width: 960px !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-}
-
-@media only screen and (min-width: 1200px) {
-  div.comparison__body, div.course-detail__body {
-    width: 1140px !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
 }
 

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -20,16 +20,15 @@
     <script type="text/javascript" src="{% static 'js/overview_blocks.js' %}?{% code_version %}"></script>
 
     <script>
-
         var compare_list = JSON.parse(localStorage.getItem("compareCourses"));
 
-        function toggle_icon(icon_id) {
+        function toggle_icon(icon_id){
             var icon_name = "#" + icon_id;
             $(icon_name).toggleClass("fa-plus");
             $(icon_name).toggleClass("fa-minus");
         }
 
-        function removeCourseCompare(index) {
+        function removeCourseCompare(index){
             compare_list.splice(index, 1);
             localStorage.setItem('compareCourses', JSON.stringify(compare_list));
 
@@ -40,101 +39,110 @@
             form.submit();
         }
 
-        window.addEventListener("load", function () {
+        window.addEventListener("load", function(){
             var saved_institutions = JSON.parse(localStorage.getItem("comparisonCourses"));
             var add_courses_link = document.getElementById("addCoursesLink")
             var add_courses_button = document.getElementById("addCourses")
             var id_list = [];
             var hidden_check = document.getElementById("hiddenCourseCompare");
 
-            for (var i = 0; i < compare_list.length; i++) {
+            for(var i = 0; i < compare_list.length; i++){
                 id_list.push(compare_list[i].id);
             }
 
             var index = 0
-            for (var i = 0; i < saved_institutions.length; i++) {
+            for(var i = 0; i < saved_institutions.length; i++){
                 let courseId = saved_institutions[i].courseId
                 let query = saved_institutions[i].uniId + ',' + courseId + ',' + saved_institutions[i].mode.en
 
-                if (id_list.includes(courseId)) {
+                if(id_list.includes(courseId)){
                     document.getElementById("hiddenCourseCompare").innerHTML += `<input id="${'course' + index}" type="checkbox" value="${query}" name="courses" hidden checked>`
                     index++
                 }
             }
 
-            if (compare_list.length === 7) {
+            if(compare_list.length === 7){
                 add_courses_link.href = "";
                 add_courses_button.disabled = true;
                 add_courses_button.style.backgroundColor = "grey";
             }
+
+            for(var index = 0; index < compare_list.length; index++)
+                for(var i = 1; i <= compare_list[index].rating; i++){
+                    var star = document.getElementById("course-" + index + "-star" + i);
+                    star.innerHTML = "★";
+                    star.classList.add("orange");
+            }
         });
 
-        function addStarRating(id, value, index) {
+        function addStarRating(id, value, index){
             var star = document.getElementById(id);
 
-            if (+value > compare_list[index].rating) {
-                for (var i = 1; i <= value; i++) {
+            if(+value > compare_list[index].rating){
+                for(var i = 1; i <= value; i++){
                     var star_fill = document.getElementById("course-" + index + "-star" + i);
                     star_fill.innerHTML = "★";
                     star_fill.classList.add("orange");
                 }
                 compare_list[index].rating = +value
-            } else if (+value < compare_list[index].rating) {
-                for (var i = 3; i > +value; i--) {
+            }
+            else if(+value < compare_list[index].rating){
+                for(var i = 3; i > +value; i--){
                     var star_fill = document.getElementById("course-" + index + "-star" + i);
                     star_fill.innerHTML = "☆";
                     star_fill.classList.remove("orange");
                 }
                 compare_list[index].rating = +value
-            } else if (compare_list[index].rating == +value) {
-                star.innerHTML = '☆';
-                star.classList.remove("orange");
-                compare_list[index].rating = +value - 1;
             }
+            else if(+value == compare_list[index].rating){
+                for(var i = 3; i > +value; i--){
+                    var star_fill = document.getElementById("course-" + index + "-star" + i);
+                    star_fill.innerHTML = "☆";
+                    star_fill.classList.remove("orange");
+                }
+                compare_list[index].rating = +value - 1
+            }
+
 
             localStorage.setItem('compareCourses', JSON.stringify(compare_list));
         }
 
-        var temp_value = 0
+        function hoverStars(value, index, dataIndex){
 
-        function hoverStars(id, value, index) {
-            var star = document.getElementById(id);
-
-            if (+value > temp_value) {
-                for (var i = 1; i <= value; i++) {
-                    var star_fill = document.getElementById("course-" + index + "-star" + i);
-                    star_fill.innerHTML = "★";
-                    star_fill.classList.add("orange");
+            if(+value < compare_list[index].rating){
+                for(var i = 3; i > +value; i--){
+                    var star = document.getElementById("course-" + index + "-star" + i);
+                    star.innerHTML = "☆";
+                    star.classList.remove("orange");
                 }
-                temp_value = +value
-            } else if (+value < temp_value) {
-                for (var i = 3; i > +value; i--) {
-                    var star_fill = document.getElementById("course-" + index + "-star" + i);
-                    star_fill.innerHTML = "☆";
-                    star_fill.classList.remove("orange");
+            }
+            else if(+value > 0){
+                for(var i = 1; i <= value; i++){
+                    var star = document.getElementById("course-" + index + "-star" + i);
+                    star.innerHTML = "★";
+                    star.classList.add("orange");
                 }
-                temp_value = +value
             }
         }
 
-        function mouseExitStars(index) {
-            console.log(index)
-        }
-
-        function prefillStars(index) {
-            for (i = 1; i <= compare_list[index].rating; i++) {
-                var star = document.getElementById("course-" + index + "-star" + i);
-                star.innerHTML = "★";
-                star.classList.add("orange");
+        function mouseExitStars(index){
+            for(var i = 1; i <= 3; i++){
+            var star = document.getElementById("course-" + index + "-star" + i);
+                if(i <= compare_list[index].rating){
+                    star.innerHTML = "★";
+                    star.classList.add("orange");
+                }
+                else{
+                    star.innerHTML = "☆";
+                    star.classList.remove("orange");
+                }
             }
         }
-
-
     </script>
 
     <style>
-        .orange {
-            color: orange !important;
+        .orange{
+            color: orange;
         }
     </style>
 
@@ -150,7 +158,6 @@
                     <i class="fas fa-sync-alt fa-5x align-text-bottom mx-3"></i>
                     <i class="fas fa-mobile-alt fa-rotate-90 fa-5x align-text-bottom mx-4"></i>
                 </div>
-
             </div>
             <h3 class="text-center">Please rotate your device to landscape to view this page</h3>
         </div>

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -166,19 +166,7 @@
 
 {% block content %}
 
-<div class="d-block d-sm-none comparison__xs-rotate mb-sm-4 course-comparison-body">
-    <div class="mx-auto p-4">
-        <div class="row my-3">
-            <div class="mx-auto">
-                <i class="fas fa-mobile-alt fa-5x align-text-bottom mx-3"></i>
-                <i class="fas fa-sync-alt fa-5x align-text-bottom mx-3"></i>
-                <i class="fas fa-mobile-alt fa-rotate-90 fa-5x align-text-bottom mx-4"></i>
-            </div>
-        </div>
-        <h3 class="text-center">Please rotate your device to landscape to view this page</h3>
-    </div>
-</div>
-<div class="comparison d-none d-sm-block mb-5">
+<div class="comparison d-sm-block mb-5">
     <div class="comparison__body pt-1">
 
         <h2 class="comparison__heading">
@@ -191,15 +179,14 @@
                 <p>Search our guidelines for help making the best decision for you.</p>
                 <p style="margin-bottom: 0px;">Go to Information and advice</p>
             </div>
-            <div class="comparison__top-container-add-btn" style="">
-                <a id="addCoursesLink"
-                   href="/{% get_translation key='bookmarks-manage' language=page.get_language %}/">
+            <div class="comparison__top-container-add-btn">
+
                     <button id="addCourses" class="comparison__top-container-add-btn-add-courses-button">
                         <span style="font-size:20px;">+</span> <span
                             style="padding-left: 10px;">Add saved course</span>
                     </button>
-                </a>
-                <p class="comparison__top-container-add-btn-compare-text" style="display: inline-block;">Compare up
+
+                <p class="comparison__top-container-add-btn-compare-text">Compare up
                     to 7 courses</p>
             </div>
 
@@ -216,16 +203,14 @@
 
             <div class="course-detail__course-container-pills">
                 <div class="course-detail__course-container-pills-slider"
-                     onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft"
-                     class="course-detail__course-container-pills-slider">
+                     onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft">
                     <p class="course-detail__course-container-pills-slider-arrow"> < </p>
                 </div>
                 {% for course in courses %}
                 {% include 'courses/partials/course_comparison_overview.html' %}
                 {% endfor %}
-                <div class="course-detail__course-container-pills-slider"
-                     onclick="bottom_display += 1; scrollDisplay();" id="slideRight"
-                     class="course-detail__course-container-pills-slider">
+                <div class="course-detail__course-container-pills-slider single-arrow"
+                     onclick="bottom_display += 1; scrollDisplay();" id="slideRight">
                     <p class="course-detail__course-container-pills-slider-arrow"> > </p>
                 </div>
             </div>
@@ -300,13 +285,24 @@
     </div>
 
     <script>
+
+        document.getElementById("addCourses").onclick = function () {
+            location.href = "/{% get_translation key='bookmarks-manage' language=page.get_language %}/";
+        };
+
         var bottom_display = 0;
         const slide_left = document.getElementById("slideLeft");
         const slide_right = document.getElementById("slideRight");
         const course_info_container = document.getElementById("course-info-container")
+         if(screen.availWidth < 450 || window.innerWidth < 450){
+             var small_screen_amount = 1
+         }
+         else{
+             var small_screen_amount = 2
+         }
 
         function scrollDisplay(){
-            if(bottom_display + 3 === compare_list.length){
+            if(bottom_display + small_screen_amount + 1 === compare_list.length){
                 slide_right.style.display = "none";
                 course_info_container.classList.remove("course-info-right");
             }
@@ -324,14 +320,18 @@
                 course_info_container.classList.add("course-info-left");
             }
             if(slide_left.style.display == "flex" && slide_right.style.display == "flex"){
-                slide_left.style.width = "27px";
-                slide_right.style.width = "27px";
+                slide_left.classList.remove("single-arrow");
+                slide_right.classList.remove("single-arrow");
+                slide_left.classList.add("both-arrows");
+                slide_right.classList.add("both-arrows");
                 course_info_container.classList.remove("course-info-left", "course-info-right");
                 course_info_container.classList.add("course-info-both");
             }
             else{
-                slide_left.style.width = "49px";
-                slide_right.style.width = "49px";
+                slide_left.classList.add("single-arrow");
+                slide_right.classList.add("single-arrow");
+                slide_left.classList.remove("both-arrows");
+                slide_right.classList.remove("both-arrows");
                 course_info_container.classList.remove("course-info-both");
             }
 
@@ -339,7 +339,7 @@
                 for(var index=0; index < compare_list.length; index++){
                     var course_info = document.getElementById(dataset[i] + index)
                     var course_div = document.getElementById(`courseContainer-${index}`);
-                    if(+course_div.dataset.index > bottom_display + 2 || +course_div.dataset.index < bottom_display){
+                    if(+course_div.dataset.index > bottom_display + small_screen_amount || +course_div.dataset.index < bottom_display){
                         course_div.style.display = "none";
                         course_info.style.display = "none";
                     }
@@ -352,39 +352,37 @@
         }
 
         function smallScreenDisplay(){
-            console.log(screen.availWidth)
-            if(window.innerWidth <= 768){
-                if(bottom_display === 0){
-                    slide_left.style.display = "none";
-                    course_info_container.classList.remove("course-info-left");
-                }
-                else{
-                    slide_left.style.display = "flex";
-                    course_info_container.classList.add("course-info-left")
-                }
-                if(bottom_display + 3 === compare_list.length){
-                    slide_right.style.display = "none";
-                    course_info_container.classList.remove("course-info-right");
-                }
-                else{
-
-                    slide_right.style.display = "flex";
-                    console.log(slide_right.style.display)
-                    course_info_container.classList.add("course-info-right");
-                }
+            if(screen.availWidth < 450 || window.innerWidth < 450){
+                var small_screen_amount = 1
             }
             else{
-                slide_left.style.display = "none";
-                slide_right.style.display = "none";
-                course_info_container.classList.remove("course-info-right", "course-info-left", "course-info-both");
-
+                var small_screen_amount = 2
             }
+            if(slide_left.style.display === "flex" && slide_right.style.display === "none"){
+                course_info_container.classList.add("course-info-left");
+            }
+            if(slide_right.style.display === "flex" && slide_left.style.display == "none"){
+                course_info_container.classList.add("course-info-right");
+            }
+            if(slide_left.style.display && slide_right.style.display == "flex"){
+                course_info_container.classList.remove("course-info-right");
+                course_info_container.classList.remove("course-info-left");
+                course_info_container.classList.add("course-info-both");
+            }
+            if(bottom_display === 0){
+                slide_left.style.display = "none";
+            }
+
             for(var i=0; i < 8; i++){
                 for (var index = 0; index < compare_list.length; index ++){
                     var course_info = document.getElementById(dataset[i] + index)
                     var course_div = document.getElementById(`courseContainer-${index}`);
 
-                    if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + 2 ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
+                    if(screen.availWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||screen.availWidth <= 768 && +course_div.dataset.index < bottom_display){
+                        course_div.style.display = "none";
+                        course_info.style.display = "none";
+                    }
+                    if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
                         course_div.style.display = "none";
                         course_info.style.display = "none";
                     }
@@ -395,12 +393,12 @@
                 }
             }
         }
-
-        smallScreenDisplay();
-
-        window.addEventListener("load", smallScreenDisplay);
-        window.addEventListener("resize", smallScreenDisplay);
-
+        $(window).on('load', function(){
+            smallScreenDisplay();
+        });
+        $(window).on('resize orientationchange', function(){
+            smallScreenDisplay();
+        });
 
     </script>
     {% endblock %}

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -215,10 +215,10 @@
             </form>
 
             <div class="course-detail__course-container-pills">
-                <div style="display: flex; align-items: center; justify-content:center;"
+                <div class="course-detail__course-container-pills-slider"
                      onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft"
                      class="course-detail__course-container-pills-slider">
-                    <p style="padding: 100% 0; text-align:center; font-size: 20px; font-weight: bold;"> < </p>
+                    <p class="course-detail__course-container-pills-slider-arrow"> < </p>
                 </div>
                 {% for course in courses %}
                 {% include 'courses/partials/course_comparison_overview.html' %}
@@ -352,7 +352,8 @@
         }
 
         function smallScreenDisplay(){
-            if(screen.width <= 768 || window.innerWidth){
+            console.log(screen.availWidth)
+            if(window.innerWidth <= 768){
                 if(bottom_display === 0){
                     slide_left.style.display = "none";
                     course_info_container.classList.remove("course-info-left");
@@ -383,7 +384,7 @@
                     var course_info = document.getElementById(dataset[i] + index)
                     var course_div = document.getElementById(`courseContainer-${index}`);
 
-                    if((screen.width <= 768 || window.innerWidth) && +course_div.dataset.index > bottom_display + 2 ||(screen.width <= 768 || window.innerWidth) && +course_div.dataset.index < bottom_display){
+                    if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + 2 ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
                         course_div.style.display = "none";
                         course_info.style.display = "none";
                     }
@@ -396,6 +397,7 @@
         }
 
         smallScreenDisplay();
+
         window.addEventListener("load", smallScreenDisplay);
         window.addEventListener("resize", smallScreenDisplay);
 

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -163,45 +163,55 @@
         </div>
     </div>
     <div class="comparison d-none d-sm-block mb-5">
-    <div class="comparison__body pt-1">
+        <div class="comparison__body pt-1">
 
-        <h2 class="comparison__heading">
-            {{ page.compare_heading }}
-        </h2>
+            <h2 class="comparison__heading">
+                {{ page.compare_heading }}
+            </h2>
 
-        <div class="comparison__top-container">
-            <div class="comparison__top-container-need-help-box">
-                <h4>Need help choosing?</h4>
-                <p>Search our guidelines for help making the best decision for you.</p>
-                <p style="margin-bottom: 0px;">Go to Information and advice</p>
-            </div>
-            <div class="comparison__top-container-add-btn" style="">
-                <a id="addCoursesLink"
-                   href="/{% get_translation key='bookmarks-manage' language=page.get_language %}/">
-                    <button id="addCourses" class="comparison__top-container-add-btn-add-courses-button">
-                        <span style="font-size:20px;">+</span> <span
-                            style="padding-left: 10px;">Add saved course</span>
-                    </button>
-                </a>
-                <p class="comparison__top-container-add-btn-compare-text" style="display: inline-block;">Compare up
-                    to 7 courses</p>
-            </div>
-
-        </div>
-        <div class="course-detail__course-container">
-            {% if courses %}
-                <div class="course-detail__course-selected">
-                    {{ courses|length }} courses selected
+            <div class="comparison__top-container">
+                <div class="comparison__top-container-need-help-box">
+                    <h4>Need help choosing?</h4>
+                    <p>Search our guidelines for help making the best decision for you.</p>
+                    <p style="margin-bottom: 0px;">Go to Information and advice</p>
                 </div>
-                <form id="compareForm" method="GET"
-                      action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
-                    <div id="hiddenCourseCompare"></div>
-                </form>
-                {% for course in courses %}
-                    {% include 'courses/partials/course_comparison_overview.html' %}
-                {% endfor %}
-            {% endif %}
-        </div>
+                <div class="comparison__top-container-add-btn" style="">
+                    <a id="addCoursesLink"
+                       href="/{% get_translation key='bookmarks-manage' language=page.get_language %}/">
+                        <button id="addCourses" class="comparison__top-container-add-btn-add-courses-button">
+                            <span style="font-size:20px;">+</span> <span
+                                style="padding-left: 10px;">Add saved course</span>
+                        </button>
+                    </a>
+                    <p class="comparison__top-container-add-btn-compare-text" style="display: inline-block;">Compare up
+                        to 7 courses</p>
+                </div>
+
+            </div>
+            <div class="course-detail__course-container">
+                {% if courses %}
+                    <div class="course-detail__course-selected">
+                        {{ courses|length }} courses selected
+                    </div>
+                    <form id="compareForm" method="GET"
+                          action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
+                        <div id="hiddenCourseCompare"></div>
+                    </form>
+                    {% for course in courses %}
+                    <div class="course-detail__course-container-pills">
+                        <div class="course-detail__course-container-pills-slider">
+                            <p style="margin-top: auto; margin-bottom: auto; font-size: 16px; font-weight: bold;"> < </p>
+                        </div>
+                    {% for course in courses_array %}
+                        {% include 'courses/partials/course_comparison_overview.html' %}
+                    {% endfor %}
+                        <div class="course-detail__course-container-pills-slider">
+                            <p style="margin-top: auto; margin-bottom: auto; font-size: 16px; font-weight: bold;"> > </p>
+                        </div>
+                    </div>
+
+                {% endif %}
+            </div>
 
         {% with dataset=courses_data.0.course_details %}
             <div class="course_comparison-table__row-header">

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -4,23 +4,37 @@
 
 
 {% block extra_css %}
-    <link href="{% sass_src 'scss/course_comparison.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
-    <link href="{% sass_src 'scss/course_detail.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
+<link href="{% sass_src 'scss/course_comparison.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
+<link href="{% sass_src 'scss/course_detail.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extra_js %}
-    <script type="text/javascript" src="{% static 'js/course_detail_accordions.js' %}?{% code_version %}"></script>
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/highcharts-more.js"></script>
-    <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
-    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
-    <script type="text/javascript" src="{% static 'js/doughnut_chart.js' %}?{% code_version %}"></script>
-    <script type="text/javascript" src="{% static 'js/bar_chart.js' %}?{% code_version %}"></script>
-    <script type="text/javascript" src="{% static 'js/label_explanation_popups.js' %}?{% code_version %}"></script>
-    <script type="text/javascript" src="{% static 'js/overview_blocks.js' %}?{% code_version %}"></script>
+<script type="text/javascript" src="{% static 'js/course_detail_accordions.js' %}?{% code_version %}"></script>
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+<script type="text/javascript" src="{% static 'js/doughnut_chart.js' %}?{% code_version %}"></script>
+<script type="text/javascript" src="{% static 'js/bar_chart.js' %}?{% code_version %}"></script>
+<script type="text/javascript" src="{% static 'js/label_explanation_popups.js' %}?{% code_version %}"></script>
+<script type="text/javascript" src="{% static 'js/overview_blocks.js' %}?{% code_version %}"></script>
 
-    <script>
+<style>
+    .course-info-right{
+        margin-right: 49px;
+    }
+    .course-info-left{
+        margin-left: 49px;
+    }
+    .course-info-both{
+        margin-right: 27px;
+        margin-left: 27px;
+    }
+</style>
+
+<script>
         var compare_list = JSON.parse(localStorage.getItem("compareCourses"));
+        var dataset = []
 
         function toggle_icon(icon_id){
             var icon_name = "#" + icon_id;
@@ -138,143 +152,150 @@
                 }
             }
         }
-    </script>
 
-    <style>
+</script>
+
+<style>
         .orange{
             color: orange;
         }
-    </style>
+
+</style>
 
 {% endblock %}
 
 {% block content %}
 
-    <div class="d-block d-sm-none comparison__xs-rotate mb-sm-4 course-comparison-body">
-        <div class="mx-auto p-4">
-            <div class="row my-3">
-                <div class="mx-auto">
-                    <i class="fas fa-mobile-alt fa-5x align-text-bottom mx-3"></i>
-                    <i class="fas fa-sync-alt fa-5x align-text-bottom mx-3"></i>
-                    <i class="fas fa-mobile-alt fa-rotate-90 fa-5x align-text-bottom mx-4"></i>
-                </div>
+<div class="d-block d-sm-none comparison__xs-rotate mb-sm-4 course-comparison-body">
+    <div class="mx-auto p-4">
+        <div class="row my-3">
+            <div class="mx-auto">
+                <i class="fas fa-mobile-alt fa-5x align-text-bottom mx-3"></i>
+                <i class="fas fa-sync-alt fa-5x align-text-bottom mx-3"></i>
+                <i class="fas fa-mobile-alt fa-rotate-90 fa-5x align-text-bottom mx-4"></i>
             </div>
-            <h3 class="text-center">Please rotate your device to landscape to view this page</h3>
         </div>
+        <h3 class="text-center">Please rotate your device to landscape to view this page</h3>
     </div>
-    <div class="comparison d-none d-sm-block mb-5">
-        <div class="comparison__body pt-1">
+</div>
+<div class="comparison d-none d-sm-block mb-5">
+    <div class="comparison__body pt-1">
 
-            <h2 class="comparison__heading">
-                {{ page.compare_heading }}
-            </h2>
+        <h2 class="comparison__heading">
+            {{ page.compare_heading }}
+        </h2>
 
-            <div class="comparison__top-container">
-                <div class="comparison__top-container-need-help-box">
-                    <h4>Need help choosing?</h4>
-                    <p>Search our guidelines for help making the best decision for you.</p>
-                    <p style="margin-bottom: 0px;">Go to Information and advice</p>
-                </div>
-                <div class="comparison__top-container-add-btn" style="">
-                    <a id="addCoursesLink"
-                       href="/{% get_translation key='bookmarks-manage' language=page.get_language %}/">
-                        <button id="addCourses" class="comparison__top-container-add-btn-add-courses-button">
-                            <span style="font-size:20px;">+</span> <span
-                                style="padding-left: 10px;">Add saved course</span>
-                        </button>
-                    </a>
-                    <p class="comparison__top-container-add-btn-compare-text" style="display: inline-block;">Compare up
-                        to 7 courses</p>
-                </div>
-
+        <div class="comparison__top-container">
+            <div class="comparison__top-container-need-help-box">
+                <h4>Need help choosing?</h4>
+                <p>Search our guidelines for help making the best decision for you.</p>
+                <p style="margin-bottom: 0px;">Go to Information and advice</p>
             </div>
-            <div class="course-detail__course-container">
-                {% if courses %}
-                    <div class="course-detail__course-selected">
-                        {{ courses|length }} courses selected
-                    </div>
-                    <form id="compareForm" method="GET"
-                          action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
-                        <div id="hiddenCourseCompare"></div>
-                    </form>
-
-                    <div class="course-detail__course-container-pills">
-                        <div style="display: flex; align-items: center; justify-content:center;" onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft" class="course-detail__course-container-pills-slider">
-                            <p style="padding: 100% 0; text-align:center; font-size: 20px; font-weight: bold;"> < </p>
-                        </div>
-                    {% for course in courses %}
-                        {% include 'courses/partials/course_comparison_overview.html' %}
-                    {% endfor %}
-                        <div style="display: flex; align-items: center; justify-content:center;" onclick="bottom_display += 1; scrollDisplay();" id="slideRight" class="course-detail__course-container-pills-slider">
-                            <p style="font-size: 20px; font-weight: bold;"> > </p>
-                        </div>
-                    </div>
-
-                {% endif %}
+            <div class="comparison__top-container-add-btn" style="">
+                <a id="addCoursesLink"
+                   href="/{% get_translation key='bookmarks-manage' language=page.get_language %}/">
+                    <button id="addCourses" class="comparison__top-container-add-btn-add-courses-button">
+                        <span style="font-size:20px;">+</span> <span
+                            style="padding-left: 10px;">Add saved course</span>
+                    </button>
+                </a>
+                <p class="comparison__top-container-add-btn-compare-text" style="display: inline-block;">Compare up
+                    to 7 courses</p>
             </div>
 
-        {% with dataset=courses_data.0.course_details %}
+        </div>
+        <div class="course-detail__course-container">
+            {% if courses %}
+            <div class="course-detail__course-selected">
+                {{ courses|length }} courses selected
+            </div>
+            <form id="compareForm" method="GET"
+                  action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
+                <div id="hiddenCourseCompare"></div>
+            </form>
+
+            <div class="course-detail__course-container-pills">
+                <div style="display: flex; align-items: center; justify-content:center;"
+                     onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft"
+                     class="course-detail__course-container-pills-slider">
+                    <p style="padding: 100% 0; text-align:center; font-size: 20px; font-weight: bold;"> < </p>
+                </div>
+                {% for course in courses %}
+                {% include 'courses/partials/course_comparison_overview.html' %}
+                {% endfor %}
+                <div class="course-detail__course-container-pills-slider"
+                     onclick="bottom_display += 1; scrollDisplay();" id="slideRight"
+                     class="course-detail__course-container-pills-slider">
+                    <p class="course-detail__course-container-pills-slider-arrow"> > </p>
+                </div>
+            </div>
+
+            {% endif %}
+        </div>
+        <div id="course-info-container">
+            {% with dataset=courses_data.0.course_details %}
             <div class="course_comparison-table__row-header">
                 {{ dataset.title }}
             </div>
             {% for item, value in dataset.dataset.items %}
-                {% if forloop.counter == 3 %}
-                    <!-- Hidden content start -->
-                    <div class="accordion">
-                    <div class="accordion-body">
+            {% if forloop.counter == 3 %}
+            <!-- Hidden content start -->
+            <div class="accordion">
+                <div class="accordion-body">
 
-                {% endif %}
-            {% include 'courses/partials/comparison_courses_row.html' with title=value.title values=value.values %}
-            {% if forloop.last %}
+                    {% endif %}
+                    <script>dataset.push("{{value.title}}")</script>
+                    {% include 'courses/partials/comparison_courses_row.html' with title=value.title values=value.values %}
+                    {% if forloop.last %}
                 </div>
                 <!-- Hidden content end -->
                 <!-- Show more start-->
                 {% with action=dataset.call_to_action.0.show_more %}
-                    <div tabindex="0" role="button" aria-label="{{ action.affirmative }}"
-                         class="accordion-header">
+                <div tabindex="0" role="button" aria-label="{{ action.affirmative }}"
+                     class="accordion-header">
                     <div class="accordion-title">
-                    <div class="accordion-header course_comparison-table__row-header"
-                         style="font-size: 16px; font-weight: normal;">
-                    <i class="fas fa-chevron-down expand" alt="expand"
-                       style="font-size: 20px; margin-right: 4px;"
-                       aria-label="{{ action.affirmative }}"></i>
-                    <i class="fas fa-chevron-up collapse" alt="collapse"
-                       style=" font-size: 20px;margin-right: 4px;"
-                       aria-label="{{ action.negative }}"></i>
-                    <span class="expand">{{ action.affirmative }}</span>
-                    <span class="collapse">{{ action.negative }}</span>
+                        <div class="accordion-header course_comparison-table__row-header"
+                             style="font-size: 16px; font-weight: normal;">
+                            <i class="fas fa-chevron-down expand" alt="expand"
+                               style="font-size: 20px; margin-right: 4px;"
+                               aria-label="{{ action.affirmative }}"></i>
+                            <i class="fas fa-chevron-up collapse" alt="collapse"
+                               style=" font-size: 20px;margin-right: 4px;"
+                               aria-label="{{ action.negative }}"></i>
+                            <span class="expand">{{ action.affirmative }}</span>
+                            <span class="collapse">{{ action.negative }}</span>
+                            {% endwith %}
+                        </div>
+                    </div>
+
+                </div>
+                <!-- show more end -->
+                {% endif %}
+                {% endfor %}
                 {% endwith %}
             </div>
-            </div>
 
-            </div>
-                <!-- show more end -->
-            {% endif %}
-            {% endfor %}
-        {% endwith %}
-
-
-        <div hidden class="">
-            <div class="course-detail__further-info-block">
-                <a href="/dummy-link" class="course-detail__other-courses-link">
-                    <img class="course-detail__other-courses-link-icon"
-                         src="{% static 'images/location_paddle.svg' %}"
-                         alt="">
-                    <span>{% autoescape off %}
+            <div hidden class="">
+                <div class="course-detail__further-info-block">
+                    <a href="/dummy-link" class="course-detail__other-courses-link">
+                        <img class="course-detail__other-courses-link-icon"
+                             src="{% static 'images/location_paddle.svg' %}"
+                             alt="">
+                        <span>{% autoescape off %}
                         {% get_translation key='similar_courses_here' language=page.get_language %}{% endautoescape %}</span>
-                </a>
+                    </a>
 
-                <a href="/dummy-link" class="course-detail__other-courses-link">
-                    <img class="course-detail__other-courses-link-icon"
-                         src="{% static 'images/curved_arrow_right.svg' %}"
-                         alt="">
-                    <span>{% autoescape off %}
+                    <a href="/dummy-link" class="course-detail__other-courses-link">
+                        <img class="course-detail__other-courses-link-icon"
+                             src="{% static 'images/curved_arrow_right.svg' %}"
+                             alt="">
+                        <span>{% autoescape off %}
                         {% get_translation key='similar_courses_elsewhere' language=page.get_language %}{% endautoescape %}</span>
-                </a>
+                    </a>
+                </div>
             </div>
-        </div>
 
-        <!-- {% include 'courses/partials/compare-popup-bar.html' %} -->
+            <!-- {% include 'courses/partials/compare-popup-bar.html' %} -->
         </div>
     </div>
 
@@ -282,73 +303,102 @@
         var bottom_display = 0;
         const slide_left = document.getElementById("slideLeft");
         const slide_right = document.getElementById("slideRight");
+        const course_info_container = document.getElementById("course-info-container")
 
         function scrollDisplay(){
             if(bottom_display + 3 === compare_list.length){
                 slide_right.style.display = "none";
+                course_info_container.classList.remove("course-info-right");
             }
             else{
                 slide_right.style.display = "flex";
+                course_info_container.classList.add("course-info-right");
             }
 
             if(bottom_display === 0){
                 slide_left.style.display = "none";
+                course_info_container.classList.remove("course-info-both", "course-info-left");
             }
             else{
                 slide_left.style.display = "flex";
+                course_info_container.classList.add("course-info-left");
             }
             if(slide_left.style.display == "flex" && slide_right.style.display == "flex"){
                 slide_left.style.width = "27px";
                 slide_right.style.width = "27px";
+                course_info_container.classList.remove("course-info-left", "course-info-right");
+                course_info_container.classList.add("course-info-both");
             }
             else{
                 slide_left.style.width = "49px";
                 slide_right.style.width = "49px";
+                course_info_container.classList.remove("course-info-both");
             }
 
-            for(var i=0; i < compare_list.length; i++){
-                var course_div = document.getElementById(`courseContainer-${i}`);
-                if(+course_div.dataset.index > bottom_display + 2 || +course_div.dataset.index < bottom_display){
-                    course_div.style.display = "none";
-                }
-                else{
-                    course_div.style.display = "block";
+            for(var i=0; i < 8; i++){
+                for(var index=0; index < compare_list.length; index++){
+                    var course_info = document.getElementById(dataset[i] + index)
+                    var course_div = document.getElementById(`courseContainer-${index}`);
+                    if(+course_div.dataset.index > bottom_display + 2 || +course_div.dataset.index < bottom_display){
+                        course_div.style.display = "none";
+                        course_info.style.display = "none";
+                    }
+                    else{
+                        course_div.style.display = "block";
+                        course_info.style.display = "block";
+                    }
                 }
             }
         }
 
         function smallScreenDisplay(){
-            for(var i=0; i < compare_list.length; i++){
-                var course_div = document.getElementById(`courseContainer-${i}`);
-                    if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + 2 ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
+            if(screen.width <= 768 || window.innerWidth){
+                if(bottom_display === 0){
+                    slide_left.style.display = "none";
+                    course_info_container.classList.remove("course-info-left");
+                }
+                else{
+                    slide_left.style.display = "flex";
+                    course_info_container.classList.add("course-info-left")
+                }
+                if(bottom_display + 3 === compare_list.length){
+                    slide_right.style.display = "none";
+                    course_info_container.classList.remove("course-info-right");
+                }
+                else{
+
+                    slide_right.style.display = "flex";
+                    console.log(slide_right.style.display)
+                    course_info_container.classList.add("course-info-right");
+                }
+            }
+            else{
+                slide_left.style.display = "none";
+                slide_right.style.display = "none";
+                course_info_container.classList.remove("course-info-right", "course-info-left", "course-info-both");
+
+            }
+            for(var i=0; i < 8; i++){
+                for (var index = 0; index < compare_list.length; index ++){
+                    var course_info = document.getElementById(dataset[i] + index)
+                    var course_div = document.getElementById(`courseContainer-${index}`);
+
+                    if((screen.width <= 768 || window.innerWidth) && +course_div.dataset.index > bottom_display + 2 ||(screen.width <= 768 || window.innerWidth) && +course_div.dataset.index < bottom_display){
                         course_div.style.display = "none";
+                        course_info.style.display = "none";
                     }
                     else{
                         course_div.style.display = "block";
+                        course_info.style.display = "block";
                     }
-                if(window.innerWidth <= 768){
-                    if(bottom_display === 0){
-                        slide_left.style.display = "none";
-                    }
-                    else{
-                        slide_left.style.display = "flex";
-                    }
-                    if(bottom_display + 3 === compare_list.length){
-                        slide_right.style.display = "none";
-                    }
-                    else{
-                        slide_right.style.display = "flex";
-                    }
-                }
-                else{
-                    slide_left.style.display = "none";
-                    slide_right.style.display = "none";
                 }
             }
         }
 
         smallScreenDisplay();
+        window.addEventListener("load", smallScreenDisplay);
         window.addEventListener("resize", smallScreenDisplay);
 
+
     </script>
-{% endblock %}
+    {% endblock %}

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -40,7 +40,7 @@
             <div class="comparison__top-container-need-help-box">
                 <h4>Need help choosing?</h4>
                 <p>Search our guidelines for help making the best decision for you.</p>
-                <p style="margin-bottom: 0px;">Go to Information and advice</p>
+                <p style="margin-bottom: 0px;">Go to <strong class="blue-text">Information and advice</strong></p>
             </div>
             <div class="comparison__top-container-add-btn">
 

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -197,16 +197,16 @@
                           action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
                         <div id="hiddenCourseCompare"></div>
                     </form>
-                    {% for course in courses %}
+
                     <div class="course-detail__course-container-pills">
-                        <div class="course-detail__course-container-pills-slider">
-                            <p style="margin-top: auto; margin-bottom: auto; font-size: 16px; font-weight: bold;"> < </p>
+                        <div style="display: flex; align-items: center; justify-content:center;" onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft" class="course-detail__course-container-pills-slider">
+                            <p style="padding: 100% 0; text-align:center; font-size: 20px; font-weight: bold;"> < </p>
                         </div>
-                    {% for course in courses_array %}
+                    {% for course in courses %}
                         {% include 'courses/partials/course_comparison_overview.html' %}
                     {% endfor %}
-                        <div class="course-detail__course-container-pills-slider">
-                            <p style="margin-top: auto; margin-bottom: auto; font-size: 16px; font-weight: bold;"> > </p>
+                        <div style="display: flex; align-items: center; justify-content:center;" onclick="bottom_display += 1; scrollDisplay();" id="slideRight" class="course-detail__course-container-pills-slider">
+                            <p style="font-size: 20px; font-weight: bold;"> > </p>
                         </div>
                     </div>
 
@@ -277,4 +277,78 @@
         <!-- {% include 'courses/partials/compare-popup-bar.html' %} -->
         </div>
     </div>
+
+    <script>
+        var bottom_display = 0;
+        const slide_left = document.getElementById("slideLeft");
+        const slide_right = document.getElementById("slideRight");
+
+        function scrollDisplay(){
+            if(bottom_display + 3 === compare_list.length){
+                slide_right.style.display = "none";
+            }
+            else{
+                slide_right.style.display = "flex";
+            }
+
+            if(bottom_display === 0){
+                slide_left.style.display = "none";
+            }
+            else{
+                slide_left.style.display = "flex";
+            }
+            if(slide_left.style.display == "flex" && slide_right.style.display == "flex"){
+                slide_left.style.width = "27px";
+                slide_right.style.width = "27px";
+            }
+            else{
+                slide_left.style.width = "49px";
+                slide_right.style.width = "49px";
+            }
+
+            for(var i=0; i < compare_list.length; i++){
+                var course_div = document.getElementById(`courseContainer-${i}`);
+                if(+course_div.dataset.index > bottom_display + 2 || +course_div.dataset.index < bottom_display){
+                    course_div.style.display = "none";
+                }
+                else{
+                    course_div.style.display = "block";
+                }
+            }
+        }
+
+        function smallScreenDisplay(){
+            for(var i=0; i < compare_list.length; i++){
+                var course_div = document.getElementById(`courseContainer-${i}`);
+                    if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + 2 ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
+                        course_div.style.display = "none";
+                    }
+                    else{
+                        course_div.style.display = "block";
+                    }
+                if(window.innerWidth <= 768){
+                    if(bottom_display === 0){
+                        slide_left.style.display = "none";
+                    }
+                    else{
+                        slide_left.style.display = "flex";
+                    }
+                    if(bottom_display + 3 === compare_list.length){
+                        slide_right.style.display = "none";
+                    }
+                    else{
+                        slide_right.style.display = "flex";
+                    }
+                }
+                else{
+                    slide_left.style.display = "none";
+                    slide_right.style.display = "none";
+                }
+            }
+        }
+
+        smallScreenDisplay();
+        window.addEventListener("resize", smallScreenDisplay);
+
+    </script>
 {% endblock %}

--- a/courses/templates/courses/course_comparison_page.html
+++ b/courses/templates/courses/course_comparison_page.html
@@ -10,6 +10,7 @@
 
 {% block extra_js %}
 <script type="text/javascript" src="{% static 'js/course_detail_accordions.js' %}?{% code_version %}"></script>
+<script type="text/javascript" src="{% static 'js/ratings.js' %}?{% code_version %}"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
@@ -19,148 +20,10 @@
 <script type="text/javascript" src="{% static 'js/label_explanation_popups.js' %}?{% code_version %}"></script>
 <script type="text/javascript" src="{% static 'js/overview_blocks.js' %}?{% code_version %}"></script>
 
-<style>
-    .course-info-right{
-        margin-right: 49px;
-    }
-    .course-info-left{
-        margin-left: 49px;
-    }
-    .course-info-both{
-        margin-right: 27px;
-        margin-left: 27px;
-    }
-</style>
-
 <script>
         var compare_list = JSON.parse(localStorage.getItem("compareCourses"));
         var dataset = []
-
-        function toggle_icon(icon_id){
-            var icon_name = "#" + icon_id;
-            $(icon_name).toggleClass("fa-plus");
-            $(icon_name).toggleClass("fa-minus");
-        }
-
-        function removeCourseCompare(index){
-            compare_list.splice(index, 1);
-            localStorage.setItem('compareCourses', JSON.stringify(compare_list));
-
-            var checkbox = document.getElementById("course" + index);
-            const form = document.getElementById("compareForm");
-            checkbox.checked = false;
-
-            form.submit();
-        }
-
-        window.addEventListener("load", function(){
-            var saved_institutions = JSON.parse(localStorage.getItem("comparisonCourses"));
-            var add_courses_link = document.getElementById("addCoursesLink")
-            var add_courses_button = document.getElementById("addCourses")
-            var id_list = [];
-            var hidden_check = document.getElementById("hiddenCourseCompare");
-
-            for(var i = 0; i < compare_list.length; i++){
-                id_list.push(compare_list[i].id);
-            }
-
-            var index = 0
-            for(var i = 0; i < saved_institutions.length; i++){
-                let courseId = saved_institutions[i].courseId
-                let query = saved_institutions[i].uniId + ',' + courseId + ',' + saved_institutions[i].mode.en
-
-                if(id_list.includes(courseId)){
-                    document.getElementById("hiddenCourseCompare").innerHTML += `<input id="${'course' + index}" type="checkbox" value="${query}" name="courses" hidden checked>`
-                    index++
-                }
-            }
-
-            if(compare_list.length === 7){
-                add_courses_link.href = "";
-                add_courses_button.disabled = true;
-                add_courses_button.style.backgroundColor = "grey";
-            }
-
-            for(var index = 0; index < compare_list.length; index++)
-                for(var i = 1; i <= compare_list[index].rating; i++){
-                    var star = document.getElementById("course-" + index + "-star" + i);
-                    star.innerHTML = "★";
-                    star.classList.add("orange");
-            }
-        });
-
-        function addStarRating(id, value, index){
-            var star = document.getElementById(id);
-
-            if(+value > compare_list[index].rating){
-                for(var i = 1; i <= value; i++){
-                    var star_fill = document.getElementById("course-" + index + "-star" + i);
-                    star_fill.innerHTML = "★";
-                    star_fill.classList.add("orange");
-                }
-                compare_list[index].rating = +value
-            }
-            else if(+value < compare_list[index].rating){
-                for(var i = 3; i > +value; i--){
-                    var star_fill = document.getElementById("course-" + index + "-star" + i);
-                    star_fill.innerHTML = "☆";
-                    star_fill.classList.remove("orange");
-                }
-                compare_list[index].rating = +value
-            }
-            else if(+value == compare_list[index].rating){
-                for(var i = 3; i > +value; i--){
-                    var star_fill = document.getElementById("course-" + index + "-star" + i);
-                    star_fill.innerHTML = "☆";
-                    star_fill.classList.remove("orange");
-                }
-                compare_list[index].rating = +value - 1
-            }
-
-
-            localStorage.setItem('compareCourses', JSON.stringify(compare_list));
-        }
-
-        function hoverStars(value, index, dataIndex){
-
-            if(+value < compare_list[index].rating){
-                for(var i = 3; i > +value; i--){
-                    var star = document.getElementById("course-" + index + "-star" + i);
-                    star.innerHTML = "☆";
-                    star.classList.remove("orange");
-                }
-            }
-            else if(+value > 0){
-                for(var i = 1; i <= value; i++){
-                    var star = document.getElementById("course-" + index + "-star" + i);
-                    star.innerHTML = "★";
-                    star.classList.add("orange");
-                }
-            }
-        }
-
-        function mouseExitStars(index){
-            for(var i = 1; i <= 3; i++){
-            var star = document.getElementById("course-" + index + "-star" + i);
-                if(i <= compare_list[index].rating){
-                    star.innerHTML = "★";
-                    star.classList.add("orange");
-                }
-                else{
-                    star.innerHTML = "☆";
-                    star.classList.remove("orange");
-                }
-            }
-        }
-
 </script>
-
-<style>
-        .orange{
-            color: orange;
-        }
-
-</style>
 
 {% endblock %}
 
@@ -181,10 +44,10 @@
             </div>
             <div class="comparison__top-container-add-btn">
 
-                    <button id="addCourses" class="comparison__top-container-add-btn-add-courses-button">
-                        <span style="font-size:20px;">+</span> <span
-                            style="padding-left: 10px;">Add saved course</span>
-                    </button>
+                    <a id="addCourses" href="/{% get_translation key='bookmarks-manage' language=page.get_language %}/" class="comparison__top-container-add-btn-add-courses-button">
+                        <span style="font-size:20px;">+</span>
+                        <span>&nbsp; Add saved course</span>
+                    </a>
 
                 <p class="comparison__top-container-add-btn-compare-text">Compare up
                     to 7 courses</p>
@@ -193,28 +56,27 @@
         </div>
         <div class="course-detail__course-container">
             {% if courses %}
-            <div class="course-detail__course-selected">
-                {{ courses|length }} courses selected
-            </div>
-            <form id="compareForm" method="GET"
-                  action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
-                <div id="hiddenCourseCompare"></div>
-            </form>
-
-            <div class="course-detail__course-container-pills">
-                <div class="course-detail__course-container-pills-slider"
-                     onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft">
-                    <p class="course-detail__course-container-pills-slider-arrow"> < </p>
+                <div class="course-detail__course-selected">
+                    {{ courses|length }} courses selected
                 </div>
-                {% for course in courses %}
-                {% include 'courses/partials/course_comparison_overview.html' %}
-                {% endfor %}
-                <div class="course-detail__course-container-pills-slider single-arrow"
-                     onclick="bottom_display += 1; scrollDisplay();" id="slideRight">
-                    <p class="course-detail__course-container-pills-slider-arrow"> > </p>
-                </div>
-            </div>
+                <form id="compareForm" method="GET"
+                      action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
+                    <div id="hiddenCourseCompare"></div>
+                </form>
 
+                <div class="course-detail__course-container-pills">
+                    <div class="course-detail__course-container-pills-slider"
+                         onclick="bottom_display -= 1; scrollDisplay();" id="slideLeft">
+                        <i class="course-detail__course-container-pills-slider-arrow fas fa-chevron-left"></i>
+                    </div>
+                    {% for course in courses %}
+                        {% include 'courses/partials/course_comparison_overview.html' %}
+                    {% endfor %}
+                    <div class="course-detail__course-container-pills-slider single-arrow"
+                         onclick="bottom_display += 1; scrollDisplay();" id="slideRight">
+                        <i class="course-detail__course-container-pills-slider-arrow fas fa-chevron-right"></i>
+                    </div>
+                </div>
             {% endif %}
         </div>
         <div id="course-info-container">
@@ -239,13 +101,10 @@
                 <div tabindex="0" role="button" aria-label="{{ action.affirmative }}"
                      class="accordion-header">
                     <div class="accordion-title">
-                        <div class="accordion-header course_comparison-table__row-header"
-                             style="font-size: 16px; font-weight: normal;">
-                            <i class="fas fa-chevron-down expand" alt="expand"
-                               style="font-size: 20px; margin-right: 4px;"
+                        <div class="accordion-header course_comparison-table__row-header">
+                            <i class="fas fa-chevron-down expand chevron" alt="expand"
                                aria-label="{{ action.affirmative }}"></i>
-                            <i class="fas fa-chevron-up collapse" alt="collapse"
-                               style=" font-size: 20px;margin-right: 4px;"
+                            <i class="fas fa-chevron-up collapse chevron" alt="collapse"
                                aria-label="{{ action.negative }}"></i>
                             <span class="expand">{{ action.affirmative }}</span>
                             <span class="collapse">{{ action.negative }}</span>
@@ -279,126 +138,9 @@
                     </a>
                 </div>
             </div>
-
             <!-- {% include 'courses/partials/compare-popup-bar.html' %} -->
         </div>
     </div>
-
-    <script>
-
-        document.getElementById("addCourses").onclick = function () {
-            location.href = "/{% get_translation key='bookmarks-manage' language=page.get_language %}/";
-        };
-
-        var bottom_display = 0;
-        const slide_left = document.getElementById("slideLeft");
-        const slide_right = document.getElementById("slideRight");
-        const course_info_container = document.getElementById("course-info-container")
-         if(screen.availWidth < 450 || window.innerWidth < 450){
-             var small_screen_amount = 1
-         }
-         else{
-             var small_screen_amount = 2
-         }
-
-        function scrollDisplay(){
-            if(bottom_display + small_screen_amount + 1 === compare_list.length){
-                slide_right.style.display = "none";
-                course_info_container.classList.remove("course-info-right");
-            }
-            else{
-                slide_right.style.display = "flex";
-                course_info_container.classList.add("course-info-right");
-            }
-
-            if(bottom_display === 0){
-                slide_left.style.display = "none";
-                course_info_container.classList.remove("course-info-both", "course-info-left");
-            }
-            else{
-                slide_left.style.display = "flex";
-                course_info_container.classList.add("course-info-left");
-            }
-            if(slide_left.style.display == "flex" && slide_right.style.display == "flex"){
-                slide_left.classList.remove("single-arrow");
-                slide_right.classList.remove("single-arrow");
-                slide_left.classList.add("both-arrows");
-                slide_right.classList.add("both-arrows");
-                course_info_container.classList.remove("course-info-left", "course-info-right");
-                course_info_container.classList.add("course-info-both");
-            }
-            else{
-                slide_left.classList.add("single-arrow");
-                slide_right.classList.add("single-arrow");
-                slide_left.classList.remove("both-arrows");
-                slide_right.classList.remove("both-arrows");
-                course_info_container.classList.remove("course-info-both");
-            }
-
-            for(var i=0; i < 8; i++){
-                for(var index=0; index < compare_list.length; index++){
-                    var course_info = document.getElementById(dataset[i] + index)
-                    var course_div = document.getElementById(`courseContainer-${index}`);
-                    if(+course_div.dataset.index > bottom_display + small_screen_amount || +course_div.dataset.index < bottom_display){
-                        course_div.style.display = "none";
-                        course_info.style.display = "none";
-                    }
-                    else{
-                        course_div.style.display = "block";
-                        course_info.style.display = "block";
-                    }
-                }
-            }
-        }
-
-        function smallScreenDisplay(){
-            if(screen.availWidth < 450 || window.innerWidth < 450){
-                var small_screen_amount = 1
-            }
-            else{
-                var small_screen_amount = 2
-            }
-            if(slide_left.style.display === "flex" && slide_right.style.display === "none"){
-                course_info_container.classList.add("course-info-left");
-            }
-            if(slide_right.style.display === "flex" && slide_left.style.display == "none"){
-                course_info_container.classList.add("course-info-right");
-            }
-            if(slide_left.style.display && slide_right.style.display == "flex"){
-                course_info_container.classList.remove("course-info-right");
-                course_info_container.classList.remove("course-info-left");
-                course_info_container.classList.add("course-info-both");
-            }
-            if(bottom_display === 0){
-                slide_left.style.display = "none";
-            }
-
-            for(var i=0; i < 8; i++){
-                for (var index = 0; index < compare_list.length; index ++){
-                    var course_info = document.getElementById(dataset[i] + index)
-                    var course_div = document.getElementById(`courseContainer-${index}`);
-
-                    if(screen.availWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||screen.availWidth <= 768 && +course_div.dataset.index < bottom_display){
-                        course_div.style.display = "none";
-                        course_info.style.display = "none";
-                    }
-                    if(window.innerWidth <= 768 && +course_div.dataset.index > bottom_display + small_screen_amount ||window.innerWidth <= 768 && +course_div.dataset.index < bottom_display){
-                        course_div.style.display = "none";
-                        course_info.style.display = "none";
-                    }
-                    else{
-                        course_div.style.display = "block";
-                        course_info.style.display = "block";
-                    }
-                }
-            }
-        }
-        $(window).on('load', function(){
-            smallScreenDisplay();
-        });
-        $(window).on('resize orientationchange', function(){
-            smallScreenDisplay();
-        });
-
-    </script>
+    <script type="text/javascript" src="{% static 'js/arrows.js' %}?{% code_version %}"></script>
     {% endblock %}
+</div>

--- a/courses/templates/courses/course_manage_page.html
+++ b/courses/templates/courses/course_manage_page.html
@@ -104,13 +104,12 @@
 
     function checkSelectedOnLoad(id){
         for(var i = 0; i < compare_list.length; i++) {
-            
-                if(id.includes(compare_list[i].id)){
-                    var index = id.indexOf(compare_list[i].id)
-                    document.getElementById(id[index]).checked = true
-                    checked_bookmark += 1
-                }
+            if(id.includes(compare_list[i].id)){
+                var index = id.indexOf(compare_list[i].id)
+                document.getElementById(id[index]).checked = true
+                checked_bookmark += 1
             }
+        }
     }
 
     function savedInstitutions(){
@@ -149,7 +148,7 @@
                         {% get_translation key='location' language=page.get_language %}: <span class="location"></span>
                     </p>
 
-                    <button class="bookmark__course-remove">
+                    <button type="button" class="bookmark__course-remove" onclick="handleCourseRemoval(this)">
                         <img class="bookmark__course-remove-icon" src="{% static 'images/bin.svg' %}" alt=""> {% get_translation key='remove_course' language=page.get_language %}
                     </button>
                 </div>
@@ -174,14 +173,14 @@
             {{page.none_selected_text | richtext}}
 
             <div class="bookmark__none-selected-example">
-                <button class="course-detail__compare-btn">
+                <button class="course-detail__bookmark-compare-btn">
                     <img class="add" src="{% static 'images/grey-bookmark.svg' %}" alt="">
                      {% get_translation key='bookmark_course' language=page.get_language %}
                 </button>
 
                 <img class="down-arrow" src="{% static 'images/down-arrow.svg' %}" alt="">
 
-                <button class="course-detail__compare-btn selected">
+                <button class="course-detail__bookmark-compare-btn selected">
                     <img class="remove" src="{% static 'images/white-bookmark.svg' %}" alt="">
                      {% get_translation key='bookmark_course' language=page.get_language %}
                 </button>
@@ -193,7 +192,7 @@
         </div>
 
         <form id="compareForm" method="GET" action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
-        <div class="bookmark__courses" id="institution-bookmark"></div>
+            <div class="bookmark__courses" id="institution-bookmark"></div>
         </form>
         <script>
             savedInstitutions();

--- a/courses/templates/courses/course_manage_page.html
+++ b/courses/templates/courses/course_manage_page.html
@@ -148,7 +148,7 @@
                         {% get_translation key='location' language=page.get_language %}: <span class="location"></span>
                     </p>
 
-                    <button type="button" class="bookmark__course-remove" onclick="handleCourseRemoval(this)">
+                    <button type="button" class="bookmark__course-remove">
                         <img class="bookmark__course-remove-icon" src="{% static 'images/bin.svg' %}" alt=""> {% get_translation key='remove_course' language=page.get_language %}
                     </button>
                 </div>

--- a/courses/templates/courses/partials/comparison_courses_row.html
+++ b/courses/templates/courses/partials/comparison_courses_row.html
@@ -2,7 +2,7 @@
     <div class="course_comparison-table__column-first">
         {{ title }}
     </div>
-    <div style="display: flex; flex-direction: row; flex: 1;" class="small-flex-div">
+    <div class="small-flex-div">
     {% for item in values %}
         <div id="{{title}}{{forloop.counter0}}" class="course_comparison-table__column">
             {{ item | safe }}

--- a/courses/templates/courses/partials/comparison_courses_row.html
+++ b/courses/templates/courses/partials/comparison_courses_row.html
@@ -2,11 +2,13 @@
     <div class="course_comparison-table__column-first">
         {{ title }}
     </div>
+    <div style="display: flex; flex-direction: row; flex: 1;" class="small-flex-div">
     {% for item in values %}
-        <div class="course_comparison-table__column">
+        <div id="{{title}}{{forloop.counter0}}" class="course_comparison-table__column">
             {{ item | safe }}
         </div>
     {% endfor %}
+    </div>
 </div>
 
 

--- a/courses/templates/courses/partials/course_comparison_overview.html
+++ b/courses/templates/courses/partials/course_comparison_overview.html
@@ -1,6 +1,6 @@
 {% load staticfiles discover_uni_tags %}
 
-<div class="course-detail__courses-container">
+<div id="courseContainer-{{forloop.counter0}}" class="course-detail__courses-container" data-index="{{forloop.counter0}}">
     <div>
         <li class="rating"
                 onmouseover="hoverStars(value, {{forloop.counter0}})"
@@ -25,7 +25,7 @@
     </div>
 
     <div class="course-detail__courses-name">
-        {{course.display_title}}
+        {{course.display_title}} {% if forloop.counter0 == 3 %}testing with a really long name because why not{% endif %}
     </div>
 
     {% if page.is_english %}

--- a/courses/templates/courses/partials/course_comparison_overview.html
+++ b/courses/templates/courses/partials/course_comparison_overview.html
@@ -2,30 +2,28 @@
 
 <div class="course-detail__courses-container">
     <div>
-        <option style="display: inline-block; color: black;" class="rating"
-                onmouseover="hoverStars(id, value, {{forloop.counter0}})"
-                onmouseleave="prefillStars({{forloop.counter0}})"
+        <li class="rating"
+                onmouseover="hoverStars(value, {{forloop.counter0}})"
+                onmouseleave="mouseExitStars({{forloop.counter0}})"
                 onclick="addStarRating(id, value, {{forloop.counter0}})" id="course-{{forloop.counter0}}-star1"
                 value="1">☆
-        </option>
-        <option style="display: inline-block; color: black;" class="rating"
-                onmouseover="hoverStars(id, value, {{forloop.counter0}})"
-                onmouseleave="prefillStars({{forloop.counter0}})"
+        </li>
+        <li class="rating"
+                onmouseover="hoverStars(value, {{forloop.counter0}})"
+                onmouseleave="mouseExitStars({{forloop.counter0}})"
                 onclick="addStarRating(id, value, {{forloop.counter0}})" id="course-{{forloop.counter0}}-star2"
                 value="2">☆
-        </option>
-        <option style="display: inline-block; color: black;" class="rating"
-                onmouseover="hoverStars(id, value, {{forloop.counter0}})"
+        </li>
+        <li class="rating"
+                onmouseover="hoverStars(value, {{forloop.counter0}})"
                 onmouseleave="mouseExitStars({{forloop.counter0}})"
                 onclick="addStarRating(id, value, {{forloop.counter0}})" id="course-{{forloop.counter0}}-star3"
                 value="3">☆
-        </option>
+        </li>
         <img style="float: right; cursor: pointer;" onclick="removeCourseCompare({{ forloop.counter0 }})"
              src="{% static 'images/icon-close.svg'%}">
     </div>
-    <script>
-        prefillStars({{forloop.counter0}})
-    </script>
+
     <div class="course-detail__courses-name">
         {{course.display_title}}
     </div>

--- a/courses/templates/courses/partials/course_comparison_overview.html
+++ b/courses/templates/courses/partials/course_comparison_overview.html
@@ -20,12 +20,12 @@
                 onclick="addStarRating(id, value, {{forloop.counter0}})" id="course-{{forloop.counter0}}-star3"
                 value="3">☆
         </li>
-        <img style="float: right; cursor: pointer;" onclick="removeCourseCompare({{ forloop.counter0 }})"
+        <img class="course-detail__courses-container-exit-course" onclick="removeCourseCompare({{ forloop.counter0 }})"
              src="{% static 'images/icon-close.svg'%}">
     </div>
 
     <div class="course-detail__courses-name">
-        {{course.display_title}} {% if forloop.counter0 == 3 %}testing with a really long name because why not{% endif %}
+        {{course.display_title}}
     </div>
 
     {% if page.is_english %}


### PR DESCRIPTION
Course compare page receives courses from the bookmarks manage page.
The course compare page can now receive a maximum of 7 courses.
The UI has been updated to match zeplin.
Ratings system added.

Function added to remove courses from the course compare page via the "X".
Function added to use arrows to scroll between the courses on a smaller display.
Function added to hide some courses on smaller displays, so that they can be scrolled through with the arrows.

UI from course compare page 2 has been lined up with course compare page 1. This has been included in the scrolling function so that all the details line up with their respective courses.

Added the "Need help choosing" box.
Removed the gradient of the header to match Zeplin.
