### PR TITLE
hide placeholder content so it's not seen by the user

### DIFF
--- a/courses/static/js/bookmark_management.js
+++ b/courses/static/js/bookmark_management.js
@@ -348,6 +348,7 @@ function processWithTranslationTerms(saved_institutions, callback) {
 
         function addCourseViews(courses, template) {
             const container = document.getElementById("institution-bookmark");
+            container.hidden = false;
             courses.forEach(function (course) {
                 const courseTemplate = template.cloneNode(true);
                 courseTemplate.id = course.elementID;

--- a/courses/templates/courses/course_manage_page.html
+++ b/courses/templates/courses/course_manage_page.html
@@ -62,7 +62,7 @@
     <div class="discover-uni-container">
         <form id="compareForm" class="bookmark" method="GET"
               action="/{% get_translation key='course_comparison_link' language=page.get_language %}">
-            <div class="bookmark__courses" id="institution-bookmark">
+            <div class="bookmark__courses" id="institution-bookmark" hidden>
                 <div class="bookmark-container" id="placeholder">
                     <input class="bookmark-check"
                            name="courses"


### PR DESCRIPTION
### What

On 1st load the placeholder element for the bookmark'd courses was visible.

### How to review

run the code, and clear you cached. If you have fast connection, you've probably never seen the issue. Disabled JS in the browser and refresh the page, should see nothing but the page headings. 
