### PR TITLE
fix clash with bootstap on safari and set min and max width

### DIFF
--- a/courses/static/scss/course_comparison.scss
+++ b/courses/static/scss/course_comparison.scss
@@ -310,7 +310,7 @@ $course_comparison_first_column_width: 250px;
     }
   }
 
-  .container {
+  &-container {
     min-width: 100%;
     padding: 0;
     margin: 0;
@@ -1193,13 +1193,13 @@ $course_comparison_first_column_width: 250px;
     justify-content: flex-start;
 
     .box {
-      min-width: 0;
       max-width: 186px;
+      min-width: 186px;
       margin-right: 4px;
       max-height: 218px;
     }
 
-    .container {
+    &-container {
       min-width: 0;
       width: 100%
     }
@@ -1371,11 +1371,12 @@ $course_comparison_first_column_width: 250px;
     .box {
       min-width: 0;
       max-width: 250px;
+      min-width: 250px;
       margin-right: 8px;
       max-height: 170px;
     }
 
-    .container {
+    &-container {
       min-width: 0;
       width: 100%
     }

--- a/courses/templates/courses/partials/subject_selector.html
+++ b/courses/templates/courses/partials/subject_selector.html
@@ -4,7 +4,7 @@
         <div class="header">{% get_translation key='show_data_from' language=page.get_language %}</div>
         <div>{% get_translation key='subject_select_text' language=page.get_language %}</div>
     </div>
-    <div class="container">
+    <div class="subject_wrapper-container">
         <div class="header">{% get_translation key='select_subject' language=page.get_language %}</div>
         <div id="subjects-testing" class="subjects">
             {% for items in subjects.subject %}


### PR DESCRIPTION
### What

Spotted some frontend visual inconsistencies on Safari. 
-  clashing with bootstrap on Safari renamed class to resolve
- width of row headings wasn't be respected added min and max-width to resolve.

### How to review
Pull and open on safari review any row with multiple subjects spacing should look like other rows now. Safari issue only