### PR TITLE
Accordion headers take up too much screen realestate when the screen …

### DIFF
--- a/coursefinder/static/scss/course_finder.scss
+++ b/coursefinder/static/scss/course_finder.scss
@@ -54,7 +54,7 @@
         
 
         input#institution_query-search.search-field-input {
-            border-width: 1px solid #ced4da !important;
+            border: 1px solid #ced4da !important;
             width: 100%;
             border-radius: 5px 5px 5px 5px;
             font-size: 1rem;
@@ -534,15 +534,16 @@
                     display: flex;
                     justify-content: space-between;
                     align-items: center;
-                    padding: 29px 40px 29px 29px;
+                    padding: 20px 40px 20px 29px;
 
                     @include green-gradient-background-mixin();
                     border: 3px solid transparent;
                     cursor: pointer;
+
                     .course-finder-results__result-accordion-title, .course-finder-results__result-accordion-overview {
                         color: white;
                     }
-                    
+
 
                     // &:hover {
                     //     border: 3px solid $gradient-light-green;

--- a/courses/static/scss/accordions.scss
+++ b/courses/static/scss/accordions.scss
@@ -33,7 +33,7 @@
 
 @media only screen and (min-width: 780px) {
   .accordion-padding {
-    padding: 29px 40px 29px 29px;
+    padding: 20px 40px 20px 29px;
   }
   .accordion-title {
     font-size: 20px;


### PR DESCRIPTION
…isn't long

Reduced the height of the accordions, still bigger than mobile/tablet but saves on real estate making multiple subject course generally visible on most screen sizes