### PR TITLE
Feature/bau override unavailable

### DIFF
--- a/courses/models/jobtypestats.py
+++ b/courses/models/jobtypestats.py
@@ -43,6 +43,7 @@ class JobTypeStatistics:
             self.display_unavailable_info = display_unavailable_info(
                 self,
                 aggregation_level=self.aggregation_level,
+                replace=True
             )
             self.unavailable_reason_body = self.display_unavailable_info["reason_body"]
 

--- a/courses/models/utils.py
+++ b/courses/models/utils.py
@@ -29,12 +29,16 @@ def display_unavailable_info(self, aggregation_level, replace=False):
             "find_out_more"] = self.unavailable_find_out_more_welsh if self.unavailable_find_out_more_welsh else self.unavailable_find_out_more_english
 
     if "reason" in unavailable:
-        if replace and str(aggregation_level) in ["11", "12", "13", "21", "22", "23"]:
+        #### Remove once OFS want the override disabled ####
+        if replace and str(aggregation_level) in ["21", "22", "23"]:
             if self.display_language == enums.languages.ENGLISH:
                 unavailable["reason_body"] = unavailable["reason"].replace(" over the previous two years", "")
             else:
                 unavailable["reason_body"] = unavailable["reason"].replace("eraill yn ystod y ddwy flynedd flaenorol",
                                                                            "eraill")
+        elif replace and str(aggregation_level) == "24":
+            unavailable["reason_body"] = None
+        ########
         elif str(aggregation_level) in ["11", "12", "13", "21", "22", "23"]:
             unavailable["reason_body"] = unavailable["reason"]
         else:

--- a/courses/models/utils.py
+++ b/courses/models/utils.py
@@ -29,7 +29,7 @@ def display_unavailable_info(self, aggregation_level, replace=False):
             "find_out_more"] = self.unavailable_find_out_more_welsh if self.unavailable_find_out_more_welsh else self.unavailable_find_out_more_english
 
     if "reason" in unavailable:
-        #### Remove once OFS want the override disabled ####
+        #TODO: Remove once OFS want the override disabled https://app.clickup.com/t/j337mq
         if replace and str(aggregation_level) in ["21", "22", "23"]:
             if self.display_language == enums.languages.ENGLISH:
                 unavailable["reason_body"] = unavailable["reason"].replace(" over the previous two years", "")
@@ -38,7 +38,7 @@ def display_unavailable_info(self, aggregation_level, replace=False):
                                                                            "eraill")
         elif replace and str(aggregation_level) == "24":
             unavailable["reason_body"] = None
-        ########
+        # end remove
         elif str(aggregation_level) in ["11", "12", "13", "21", "22", "23"]:
             unavailable["reason_body"] = unavailable["reason"]
         else:

--- a/courses/renderer/sections/employment.py
+++ b/courses/renderer/sections/employment.py
@@ -102,7 +102,8 @@ class SubEmploymentSection(Section):
             if section[0] in subtitles:
                 data[section[0]]["subtitle"] = self.term_for_key(subtitles[section[0]], self.language)
 
-    # Remove below method and use set_unavailable from base class when OFS want to remove the unavailable message override
+    #TODO: Remove below method and use set_unavailable from base class when OFS want to remove the unavailable message override
+    # https://app.clickup.com/t/j337mq
     @classmethod
     def set_unavailable(
             cls,
@@ -122,3 +123,4 @@ class SubEmploymentSection(Section):
             body = _object["reason"]
 
         return ["unavailable", header, body]
+    # end remove

--- a/courses/renderer/sections/employment.py
+++ b/courses/renderer/sections/employment.py
@@ -1,4 +1,6 @@
 from typing import List, Tuple, Any, Dict
+
+from CMS import translations
 from courses.renderer.sections.base import Section
 from courses.renderer.sections.unavailable import get_unavailable
 from courses.models import Course
@@ -99,3 +101,24 @@ class SubEmploymentSection(Section):
         for section in self.sections:
             if section[0] in subtitles:
                 data[section[0]]["subtitle"] = self.term_for_key(subtitles[section[0]], self.language)
+
+    # Remove below method and use set_unavailable from base class when OFS want to remove the unavailable message override
+    @classmethod
+    def set_unavailable(
+            cls,
+            course: Course,
+            model_list: str,
+            language: str,
+            index=0,
+    ):
+        try:
+            accordion = translations.term_for_key(key="employment_15_months", language=language)
+            _object = getattr(course, model_list)[index]
+            body = getattr(_object, "unavailable_reason_body")
+            header = get_unavailable(course, model_list, language, accordion)["header"][0]
+        except Exception as e:
+            header = translations.term_for_key(key="no_data_available", language=language)
+            _object = getattr(course, "display_no_data")()
+            body = _object["reason"]
+
+        return ["unavailable", header, body]

--- a/courses/renderer/sections/graduate_perception.py
+++ b/courses/renderer/sections/graduate_perception.py
@@ -100,7 +100,8 @@ class GraduatePerceptionSection(Section):
                 data[section[0]]["subtitle"] = self.term_for_key(subtitles[section[0]], self.language)
 
 
-    #Remove below method and use set_unavailable from base class when OFS want to remove the unavailable message override
+    #TODO: Remove below method and use set_unavailable from base class when OFS want to remove the unavailable message override.
+    # https://app.clickup.com/t/j337mq
     @classmethod
     def set_unavailable(
             cls,
@@ -120,3 +121,4 @@ class GraduatePerceptionSection(Section):
             body = _object["reason"]
 
         return ["unavailable", header, body]
+    # end remove

--- a/courses/renderer/sections/unavailable.py
+++ b/courses/renderer/sections/unavailable.py
@@ -139,7 +139,8 @@ def _getattr(obj, attr, fallback):
     return getattr(obj, attr) if hasattr(obj, attr) else fallback
 
 
-# This is a temporary override. Remove once OFS have stated they want to disable the override.
+#TODO: This is a temporary override. Remove once OFS have stated they want to disable the override.
+# Remove accordion from all parameters too. https://app.clickup.com/t/j337mq
 def temporary_override(aggregation_level: str, language: str):
     if aggregation_level == "24":
         header = translations.term_for_key(key="this_course", language=language)
@@ -147,4 +148,4 @@ def temporary_override(aggregation_level: str, language: str):
     elif aggregation_level in ["21", "22", "23"]:
         header = translations.term_for_key(key="message_1_header", language=language)
         return header
-
+# end remove


### PR DESCRIPTION
### What

Added an override for the Employment after 15 months and Graduate perceptions accordions:
Removed "over two years" and edited the message accordingly when the conditions are met.

Function in employment.py and graduate_perceptions.py has been indicated with a comment that this can be removed when the override is no longer necessary.

If conditions have been marked with a comment that they can be removed when the override is no longer necessary.

### Conditions: 

- aggregation level is 21, 22, 23 or 24
- Accordion is employment or graduate