### PR TITLE
Translation fixes

### DIFF
--- a/CMS/templates/partials/course_result.html
+++ b/CMS/templates/partials/course_result.html
@@ -49,7 +49,7 @@
 
 
     {% if sort_by_subject_enabled == 'true' %}
-        <a href="{% if page.is_welsh %}/cy{% endif %}/course-details/{{ institution_id }}/{{ item.kis_course_id }}/{{ item.mode }}"
+        <a href="{% if not page.is_english %}/cy{% endif %}/course-details/{{ institution_id }}/{{ item.kis_course_id }}/{{ item.mode }}"
            class="course-finder-results__result-accordion-body-sort-by-subject-course-name">
             {{ course_name }}
         </a>
@@ -57,7 +57,7 @@
             {{ course.institution.pub_ukprn_name }}
         </p>
     {% else %}
-        <a href="{% if page.is_welsh %}/cy{% endif %}/course-details/{{ institution_id }}/{{ course.kis_course_id }}/{{ course.mode }}"
+        <a href="{% if not page.is_english %}/cy{% endif %}/course-details/{{ institution_id }}/{{ course.kis_course_id }}/{{ course.mode }}"
            class="course-finder-results__result-accordion-body-course-name">
             {{ course_name }}
         </a>

--- a/CMS/translations/dictionaries/general.py
+++ b/CMS/translations/dictionaries/general.py
@@ -162,7 +162,7 @@ DICT = {
         "en": "Search by course or location"
     },
     "can_compare_courses": {
-        "cy": "Gymharu cyrsiau",
+        "cy": "Cymharu cyrsiau",
         "en": "Compare courses"
     },
     "chart_label_explained": {
@@ -292,6 +292,10 @@ DICT = {
     "course_removed": {
         "cy": "Cwrs wedi’i ddileu o'r ",
         "en": "Course removed from "
+    },
+    "course_saved": {
+        "cy": "Cwrs wedi’i gadw",
+        "en": "Course saved"
     },
     "course_search": {
         "cy": "Chwilio am Gwrs ",
@@ -1015,6 +1019,10 @@ DICT = {
         "cy": "Cyrsiau wedi’u cadw",
         "en": "Saved courses"
     },
+    "saved_courses_lower": {
+        "cy": "gyrsiau wedi’u cadw",
+        "en": "saved courses"
+    },
     "scotland": {
         "cy": "Yr Alban",
         "en": "Scotland"
@@ -1402,6 +1410,10 @@ DICT = {
     "you_can": {
         "cy": "Gallwch ",
         "en": "You can"
+    },
+    "view_saved_courses": {
+        "cy": "Gweld cyrsiau wedi’u cadw",
+        "en": "View saved courses"
     },
     "youre_interested_in": {
         "cy": "sydd o ddiddordeb iti",

--- a/CMS/translations/dictionaries/unavailable.py
+++ b/CMS/translations/dictionaries/unavailable.py
@@ -57,7 +57,7 @@ UNAVAILABLE = {
     },
     'message_2_header': {
         'en': "This course over 2 years",
-        'cy': "Y cwrs hwn dros 2 flynedd"
+        'cy': "Daw'r data a ddangosir gan fyfyrwyr yn ystod y ddwy flynedd flaenorol."
     },
     'message_3_header': {
         'en': "This and other courses over 2 years",
@@ -69,7 +69,7 @@ UNAVAILABLE = {
     },
     'message_5_header': {
         'en': "This course over 2 years",
-        'cy': "Y cwrs hwn dros 2 flynedd."
+        'cy': "Daw'r data a ddangosir gan fyfyrwyr yn ystod y ddwy flynedd flaenorol."
     },
     'message_6_header': {
         'en': "This and other courses over 2 years",
@@ -171,6 +171,6 @@ UNAVAILABLE = {
     },
     "data_displayed": {
         'en': "The data displayed is from students on",
-        'cy': "Daw'r data a ddangosir gan fyfyrwyr ymlaen"
+        'cy': "Daw’r data a ddangosir gan fyfyrwyr ar y cwrs"
     }
 }

--- a/CMS/translations/dictionaries/unavailable.py
+++ b/CMS/translations/dictionaries/unavailable.py
@@ -57,7 +57,7 @@ UNAVAILABLE = {
     },
     'message_2_header': {
         'en': "This course over 2 years",
-        'cy': "Daw'r data a ddangosir gan fyfyrwyr yn ystod y ddwy flynedd flaenorol."
+        'cy': "Y cwrs hwn dros 2 flynedd"
     },
     'message_3_header': {
         'en': "This and other courses over 2 years",
@@ -69,7 +69,7 @@ UNAVAILABLE = {
     },
     'message_5_header': {
         'en': "This course over 2 years",
-        'cy': "Daw'r data a ddangosir gan fyfyrwyr yn ystod y ddwy flynedd flaenorol."
+        'cy': "Y cwrs hwn dros 2 flynedd"
     },
     'message_6_header': {
         'en': "This and other courses over 2 years",

--- a/courses/models/utils.py
+++ b/courses/models/utils.py
@@ -44,10 +44,18 @@ def display_unavailable_info(self, aggregation_level, replace=False):
 
 
 def separate_unavail_reason(reason_unseparated):
+    WELSH_UNAVAILABLE_UPDATES = [
+        ["yn ystod y ddwy flynedd flaenorol", "dros dwy flynedd"],
+        ["Daw'r data a ddangosir gan fyfyrwyr ar y cwrs hwn a chyrsiau Gemau cyfrifiadurol ac animeiddio eraill",
+         "Daw'r data a ddangosir gan fyfyrwyr ar y cwrs hwn a chyrsiau eraill mewn"],
+        ["Nid yw hyn yn adlewyrchu ansawdd y cwrs.", "Nid yw hyn yn adlewyrchu ar ansawdd y cwrs."]
+    ]
     index_of_delimiter = reason_unseparated.find('\n\n')
 
     if index_of_delimiter > 4:
         reason_heading = reason_unseparated[:index_of_delimiter]
+        for replacement in WELSH_UNAVAILABLE_UPDATES:
+            reason_heading = reason_heading.replace(replacement[0], replacement[1])
         reason_body = reason_unseparated[index_of_delimiter + 2:]
     else:
         reason_heading = reason_unseparated

--- a/courses/static/js/bookmark_management.js
+++ b/courses/static/js/bookmark_management.js
@@ -231,11 +231,17 @@ function processWithTranslationTerms(saved_institutions, callback) {
                 if (this.isEnglish) {
                     this.courseModeSpan.innerHTML = this.course.data.mode.en;
                     this.courseDistanceSpan.innerHTML = this.course.data.distance.en;
+                    if(this.course.data.distance.en === 0) {
+                        this.courseDistanceSpan.innerHTML = "Not Available"
+                    }
                     this.courseSandwichSpan.innerHTML = this.course.data.sandwich.en;
                     this.courseAbroadSpan.innerHTML = this.course.data.abroad.en;
                 } else {
                     this.courseModeSpan.innerHTML = this.course.data.mode.cy;
                     this.courseDistanceSpan.innerHTML = this.course.data.distance.cy;
+                    if(this.course.data.distance.cy === 0) {
+                        this.courseDistanceSpan.innerHTML = "Ddim ar gael"
+                    }
                     this.courseSandwichSpan.innerHTML = this.course.data.sandwich.cy;
                     this.courseAbroadSpan.innerHTML = this.course.data.abroad.cy;
                 }

--- a/courses/templates/courses/partials/compare-popup-bar.html
+++ b/courses/templates/courses/partials/compare-popup-bar.html
@@ -3,15 +3,15 @@
 
 <div class="compare-popup">
     <div class="compare-popup__wrapper">
-        <button class="compare-popup__close">Close x</button>
+        <button class="compare-popup__close">{% get_translation key='close' language=page.get_language %} x</button>
         <div class="compare-popup__add">
             <div class="compare-popup__left_container">
                 <p class="course_added">
                     <i class="fas fa-check-circle checkmark"></i>
-                    Course saved</p>
+                    {% get_translation key='course_saved' language=page.get_language %}</p>
                 <p class="compare-popup__count">
-                    You have saved <strong><span class="count"></span> course(s)</strong>
-                    <a class="compare-popup-saved_courses_link" href="{{manage_link}}">View saved courses</a>
+                    {% get_translation key='n_courses_bookmarked_pt_1' language=page.get_language %} <strong><span class="count"></span>&nbsp;{% get_translation key='saved_courses_lower' language=page.get_language %}</strong>
+                    <a class="compare-popup-saved_courses_link" href="{{manage_link}}">{% get_translation key='view_saved_courses' language=page.get_language %}</a>
                 </p>
             </div>
 


### PR DESCRIPTION
### What

- Compare popup now appears in Welsh
- The link for the course detail page now takes you to the Welsh page if the page is Welsh.
- Updated "Compare courses" title
- Updated Welsh translations for unavailable messages.
