### PR TITLE
fixing double '| discover uni' problem once in prod #mzcp12

### DIFF
--- a/CMS/templates/base.html
+++ b/CMS/templates/base.html
@@ -17,11 +17,7 @@
         {% block title %}
             {% if page.seo_title %}{{ page.seo_title }} | {% get_translation key='discover_uni' language=page.get_language %}{% else %}{{ page.title }} | {% get_translation key='discover_uni' language=page.get_language %}{% endif %}
         {% endblock %}
-        {% block title_suffix %}
-            {% with page.get_site.site_name as site_name %}
-                {% if site_name %}| {% get_translation key='discover_uni' language=page.get_language %}{% endif %}
-            {% endwith %}
-        {% endblock %}
+
     </title>
     <meta name="description" content=""/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>


### PR DESCRIPTION
https://app.clickup.com/t/mzcp12

Once in prod- tabs doubled up '| discover uni' - removed suffix in base 