### PR TITLE
Ndp hardcoded years updated #2tn6apu

### DIFF
--- a/courses/models/course.py
+++ b/courses/models/course.py
@@ -195,8 +195,8 @@ class Course:
 
             prefix = translations.term_for_key('average_earnings_year_range', language)
             self.go_year_range = prefix + " {}-{}".format(2018, 2020)
-            self.leo3_year_range = prefix + " {}-{}".format(2011, 2013)
-            self.leo5_year_range = prefix + " {}-{}".format(2011, 2013)
+            self.leo3_year_range = prefix + " {}-{}".format(2010, 2012)
+            self.leo5_year_range = prefix + " {}-{}".format(2010, 2012)
 
             self.go_salaries_inst = []
             if course_details.get('go_salary_inst'):


### PR DESCRIPTION
### What
https://app.clickup.com/t/2tn6apu

Instances of 2011 - 2013 reverted back to 2010 - 2012

### How to review

Go onto the course details page and make sure it reads 2010 - 2012 in the earnings section for after 3 years and after 5 years.