### PR TITLE
Ndp fix search filter #2r7f4un

### DIFF
--- a/CMS/static/js/popup.js
+++ b/CMS/static/js/popup.js
@@ -1,0 +1,5 @@
+window.addEventListener("load", () => {
+    if (document.referrer.indexOf(location.protocol + "//" + location.host) !== 0) {
+        $('#discover-modal').modal('show');
+    }
+})

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -8,7 +8,6 @@
 @import "./partials/compare";
 @import "./partials/cookie_banner";
 @import "./buttons";
-@import "./partials/popup.scss";
 
 body {
   margin: 0;

--- a/CMS/templates/base.html
+++ b/CMS/templates/base.html
@@ -115,12 +115,6 @@
     {{ page.title}}
 </button>
 
-{%  if page.title == "Course Details" or page.title == "Ynglŷn â'n data" %}
-    {% include 'partials/pop-up-course-details.html' %}
-{% elif page.title == "About our data" or page.title == "Manylion y cwrs" %}
-    {% include 'partials/pop-up-about-data.html' %}
-{% endif %}
-
     <div id="main-content" tabindex="-1">
         {% block content %}{% endblock %}
 
@@ -146,8 +140,3 @@
 
 </html>
 
-<script>
-    if (document.referrer.indexOf(location.protocol + "//" + location.host) !== 0) {
-        $('#discover-modal').modal('show');
-    }
-</script>

--- a/content/templates/content/section.html
+++ b/content/templates/content/section.html
@@ -3,9 +3,17 @@
 
 {% block extra_css %}
     <link href="{% sass_src 'scss/content.scss' %}?{% code_version %}" rel="stylesheet" type="text/css" >
+    <link href="{% sass_src 'scss/partials/popup.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
 {% endblock extra_css %}
 
+{% block extra_js %}
+    <script type="text/javascript" src="{% get_static_prefix %}js/popup.js?{% code_version %}"></script>
+{% endblock %}
+
 {% block content %}
+    {% if page.title == "About our data" or page.title == "Manylion y cwrs" %}
+        {% include 'partials/pop-up-about-data.html' %}
+    {% endif %}
     <div class="content-page section-page">
         <div class="discover-uni-container">
             {% include 'partials/breadcrumbs.html' %}

--- a/courses/templates/courses/course_detail_page.html
+++ b/courses/templates/courses/course_detail_page.html
@@ -15,15 +15,7 @@
 
 {% block extra_css %}
     <link href="{% sass_src 'scss/course_detail.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
-{% endblock %}
-
-{% block content %}
-    <div class="course_detail__header-bar px-3 pb-0 mb-0">
-        <div class="course_detail__header-bar-div col-12 p-0 text-right mx-0">
-            <img class="home-page__header-bg-icon" src="{% static 'images/bg-arrows.svg' %}" alt="Background Graphics"/>
-        </div>
-    </div>
-    {% include 'courses/course_detail_content.html' %}
+    <link href="{% sass_src 'scss/partials/popup.scss' %}?{% code_version %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extra_js %}
@@ -39,4 +31,16 @@
     <script type="text/javascript" src="{% static 'js/overview_blocks.js' %}?{% code_version %}"></script>
     <script type="text/javascript" src="{% static 'js/compare-selector.js' %}?{% code_version %}"></script>
     <script type="text/javascript" src="{% static 'js/back-button.js' %}?{% code_version %}"></script>
+    <script type="text/javascript" src="{% get_static_prefix %}js/popup.js?{% code_version %}"></script>
 {% endblock %}
+
+{% block content %}
+    {% include 'partials/pop-up-course-details.html' %}
+    <div class="course_detail__header-bar px-3 pb-0 mb-0">
+        <div class="course_detail__header-bar-div col-12 p-0 text-right mx-0">
+            <img class="home-page__header-bg-icon" src="{% static 'images/bg-arrows.svg' %}" alt="Background Graphics"/>
+        </div>
+    </div>
+    {% include 'courses/course_detail_content.html' %}
+{% endblock %}
+


### PR DESCRIPTION
### What
https://app.clickup.com/t/2r7f4un

scss from about our data and course details popup was imported into global.scss so was spilling into the search filters code and causing visual bugs. Refactored the popup code to only be included on the relevant pages.

### How to test

- On mobile view, navigate to the search page and click on show filters to check it is now displaying correctly
- On any view, navigate to a course details page from a different website - check the popup shows
- On any view navigate to the about our data page by clicking the link in NSS accordion and check the popup shows
