### PR TITLE
fix spacing on ba accounting https://discoveruni.gov.uk/course-detail…

### DIFF
--- a/courses/models/course.py
+++ b/courses/models/course.py
@@ -413,7 +413,7 @@ class Course:
         return f"{title} {at} {self.institution_name}"
 
     def display_title(self):
-        honours = ""
+        honours = " "
         if int(self.honours_award_provision) == 1:
             honours = " (Hons) "
 


### PR DESCRIPTION
…s/10007849/N4M1-U-ACCLAW/Full-time/

### What

[Course title as no spaces between type and title](https://discoveruni.gov.uk/course-details/10007849/N4M1-U-ACCLAW/Full-time/)

### How to review

Pull the code update the url for the local version and check its displayed with a spaced between BA and Accounting.
