### PR TITLE
Ndp new data fixes

### DIFF
--- a/courses/models/satisfactionstats.py
+++ b/courses/models/satisfactionstats.py
@@ -119,9 +119,16 @@ class SatisfactionStatistics:
         return self.question_22.show_data_point or self.question_23.show_data_point or \
                self.question_24.show_data_point or self.question_25.show_data_point
 
+    def show_mental_wellbeing_stats(self):
+        return self.question_26.show_data_point
+
+    def show_freedom_expression_stats(self):
+        return self.question_27.show_data_point
+
     def show_satisfaction_stats(self):
         return self.show_teaching_stats() or self.show_learning_opps_stats() or self.show_assessment_stats() or \
-               self.show_organisation_stats() or self.show_learning_resources_stats() or self.show_voice_stats()
+               self.show_organisation_stats() or self.show_learning_resources_stats() or self.show_voice_stats() or \
+               self.show_mental_wellbeing_stats() or self.show_freedom_expression_stats() or self.question_28.show_data_point
 
     def show_nhs_stats(self):
         return self.question_1.show_data_point or self.question_2.show_data_point or \

--- a/courses/models/satisfactionstats.py
+++ b/courses/models/satisfactionstats.py
@@ -201,10 +201,10 @@ class SatisfactionStatistics:
             return unavail_dict["no-data"][str(unavail_code)]
         if unavail_code == 0:
             unavail = unavail_dict["data"][str(unavail_code)][str(aggregation_level)][resp]
-            unavail.replace("[Subject]", subject)
-            return unavail
+            new_unavail = unavail.replace("[Subject]", subject)
+            return new_unavail
         if unavail_code == 1 or unavail_code == 2:
             unavail = unavail_dict["data"][str(unavail_code)][str(aggregation_level)]
-            unavail.replace("[Subject]", subject)
-            return unavail
+            new_unavail = unavail.replace("[Subject]", subject)
+            return new_unavail
 

--- a/courses/templates/courses/new_course_details/partials/earnings_after_the_course_body.html
+++ b/courses/templates/courses/new_course_details/partials/earnings_after_the_course_body.html
@@ -35,10 +35,6 @@
 
         <div class="earnings-after-course_block mx-1 mt-2 px-3 px-md-4 pt-4 pb-2">
         <div>
-        <h2 class="earnings-after-course__stats-heading text-left pt-3 pb-2">
-
-            {{ subbed_text | safe }}
-        </h2>
         {% if course_details.course_level == 4 %}
             <h4 class="kis-level-msg earnings-sector-field earnings-after-course-stat-salary-range pt-1 text-center text-lg-left mb-3">{% get_translation key='course_level_msg' language=page.get_language %}</h4>
         {% endif %}
@@ -60,7 +56,7 @@
             </div>
         {% endif %}
         <div class="earnings-after-course_explanation-text pb-2">
-            {% create_list course_details.institution.pub_ukprn_name as substitutions %}
+            {% create_list institution_name as substitutions %}
             {% insert_values_to_rich_text content=block.value.institution_graduates_heading substitutions=substitutions as subbed_text %}
             {{ subbed_text | safe }}
         </div>
@@ -279,21 +275,21 @@
                     {% if salary_index == 0 and salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc != None %}
                         <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3"
                             id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                            {% create_list salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                            {% create_list salary_aggregate.aggregated_salaries_inst.0.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.0.subject_title_in_local_language institution_name course.default_region as substitutions %}
                             {% insert_values_to_plain_text content=prov_pc_text_template_go substitutions=substitutions as subbed_text %}
                             {{ subbed_text | safe }}
                         </h4>
                     {% elif salary_index == 1 and salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc != None %}
                         <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3"
                             id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                            {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.1.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                            {% create_list salary_aggregate.aggregated_salaries_inst.1.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.1.subject_title_in_local_language institution_name course.default_region as substitutions %}
                             {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                             {{ subbed_text | safe }}
                         </h4>
                     {% elif salary_index == 2 and salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc != None %}
                         <h4 class="prov-pc-field earnings-sector-field earnings-after-course-stat-small pt-1 text-left mb-3"
                             id="{% concat 'sector_salary_graduates_' salary_index '_' salary_aggregate.subject_code %}">
-                            {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.2.subject_title_in_local_language course.institution.pub_ukprn_name course.default_region as substitutions %}
+                            {% create_list salary_aggregate.aggregated_salaries_inst.2.salary_default_country_prov_pc salary_aggregate.aggregated_salaries_inst.2.subject_title_in_local_language institution_name course.default_region as substitutions %}
                             {% insert_values_to_plain_text content=prov_pc_text_template_leo substitutions=substitutions as subbed_text %}
                             {{ subbed_text | safe }}
                         </h4>

--- a/courses/templates/courses/new_course_details/partials/student_satisfaction_body.html
+++ b/courses/templates/courses/new_course_details/partials/student_satisfaction_body.html
@@ -35,7 +35,7 @@
                     {% include 'courses/new_course_details/partials/unavailable_disclaimer.html' with unavailable=overall_stats.satisfaction_stats.unavail %}
                 </div>
                 <div class="scrolling-wrapper scroll">
-                    {% if course.country.code != "XF" %}
+                    {% if course.country.code != "XF" and overall_stats.show_satisfaction_stats %}
                         {% if question_stats.question_28.agree_or_strongly_agree %}
                             <div class="student-satisfaction__overview mt-3 p-2 flex-wrap mx-1">
                                 <div class="student-satisfaction_overall-chart left">
@@ -67,7 +67,7 @@
                                 </div>
                             </div>
                         {% endif %}
-                    {% elif course.country.code == "XF" %}
+                    {% elif course.country.code == "XF" and overall_stats.show_satisfaction_stats %}
                         <div class="student-satisfaction__data-group d-flex flex-wrap row mx-1 scroll_item additional-class">
                             <!-- freedom of expression (england) box-->
                             {% include 'courses/new_course_details/partials/student_satisfaction_1_box.html' with title="Student satisfaction" q1=question_stats.question_28 description="" no_data_key="no_data_england" %}

--- a/courses/templates/courses/new_course_details/partials/summary_boxes/course_data_summary_average_earnings_box.html
+++ b/courses/templates/courses/new_course_details/partials/summary_boxes/course_data_summary_average_earnings_box.html
@@ -5,7 +5,7 @@
         <p class="box-title">{% get_translation key="average_earnings" language=page.get_language %}</p>
         <p class="box-bold">{% if amount != "None" %}£{{ amount }}{% else %}£{{ leo3_amount }}{% endif %}</p>
         <p class="box-small">
-            {% if amount %}{% get_translation key=description language=page.get_language as first_index %}{% else %}{% get_translation key=leo3_description language=page.get_language as time %}{% endif %}
+            {% if amount != "None" %}{% get_translation key=description language=page.get_language as first_index %}{% else %}{% get_translation key=leo3_description language=page.get_language as first_index %}{% endif %}
             {% include 'courses/new_course_details/partials/summary_boxes/summary_source_grad.html' with time=time %}
         </p>
     </div>


### PR DESCRIPTION
- [Subject] in student satisfaction section replaced with the actual subject name
- Removed random message that shouldn't be there in earnings accordion
- Hide Q28 if there is no data and no other satisfaction data
- Leo messaging updated if using Leo3 in summary boxes