### PR TITLE
Refactor of courses.views.regional_earnings

### DIFF
--- a/core/templatetags/discover_uni_tags.py
+++ b/core/templatetags/discover_uni_tags.py
@@ -163,7 +163,7 @@ def get_course_locations_list(locations, is_english):
                 location_name = location.get('welsh') if location.get('welsh') else location.get('english')
                 locations_list.append(location_name)
 
-    return ','.join(locations_list)
+    return ', '.join(locations_list)
 
 
 @register.simple_tag

--- a/courses/views/views.py
+++ b/courses/views/views.py
@@ -19,219 +19,178 @@ logger = logging.getLogger(__name__)
 
 
 def regional_earnings(request):
-    if 'region' in request.POST and request.is_ajax():
-        region = request.POST['region']
-        institution_id = request.POST['institution_id']
-        course_id = request.POST['course_id']
-        kis_mode = request.POST['kis_mode']
-        subject_code = request.POST['subject_code']
-        language = request.POST['language']
-        course, error = Course.find(institution_id, course_id, kis_mode, language)
-
-        with open("./CMS/static/jsonfiles/regions.json", "r") as f:
-            regions = f.read()
-        region_full_name = "region unknown"
-        region_dict = json.loads(regions)
-        for region_elem in region_dict:
-            elem_id = region_elem['id']
-            if elem_id == region:
-                if language == 'cy':
-                    region_full_name = region_elem['name_cy']
-                else:
-                    region_full_name = region_elem['name_en']
-
-                if region_full_name[:2] == "- ":
-                    region_full_name = region_full_name[2:]
-                break
-
-        def format_thousands(earnings):
-            return f'{int(earnings):,}'
-
-        if language == 'cy':
-            # inst_prov_pc_delimiter_go = "wedi'u cyflogi yn"
-            inst_prov_pc_delimiter_go = "wedi'u cyflogi yn"
-            inst_prov_pc_delimiter_leo = "wedi'u lleoli yn"
-            inst_prov_pc_prefix = "Mae "
-        else:
-            # inst_prov_pc_delimiter_go = "are employed in"
-            inst_prov_pc_delimiter_go = "are employed in"
-            inst_prov_pc_delimiter_leo = "are based in"
-            inst_prov_pc_prefix = ""
-
-        salaries_aggregate = [element for element in course.salary_aggregates if element.subject_code == subject_code][
-            0]
-
-        unavail_msgs_go = salaries_aggregate.aggregated_salaries_sector[0].display_unavailable_info(language)
-        unavail_msgs_leo = salaries_aggregate.aggregated_salaries_sector[1].display_unavailable_info(language)
-        salary_sector_15_unavail_text = ""
-        salary_sector_3_unavail_text = ""
-        salary_sector_5_unavail_text = ""
-        unavailable_region_not_exists = ""
-        unavailable_region_not_nation = ""
-        unavailable_region_is_ni = ""
-
-        if 'unavailable_region_not_exists' in unavail_msgs_leo and unavail_msgs_leo[
-            'unavailable_region_not_exists'] != "":
-            unavailable_region_not_exists = unavail_msgs_leo['unavailable_region_not_exists']
-        if 'unavailable_region_not_nation' in unavail_msgs_go and unavail_msgs_go[
-            'unavailable_region_not_nation'] != "":
-            unavailable_region_not_nation = unavail_msgs_go['unavailable_region_not_nation']
-        if 'unavailable_region_is_ni' in unavail_msgs_leo and unavail_msgs_leo['unavailable_region_is_ni'] != "":
-            unavailable_region_is_ni = unavail_msgs_leo['unavailable_region_is_ni']
-
-        attr = getattr(salaries_aggregate.aggregated_salaries_sector[0], "med" + region, None)
-        if attr is not None:
-            if getattr(salaries_aggregate.aggregated_salaries_sector[0], "med" + region) == "" or getattr(
-                    salaries_aggregate.aggregated_salaries_sector[0], "med" + region) is None:
-                salary_sector_15_unavail_text = unavailable_region_not_exists
-            elif region not in ('_uk', '_e', '_s', '_w', '_ni'):
-                salary_sector_15_unavail_text = unavailable_region_not_nation
-
-            med = getattr(salaries_aggregate.aggregated_salaries_sector[0], "med" + region, None)
-            if med is not None and med != "NA":
-                salary_sector_15_med = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[0], "med" + region))
-                salary_sector_15_lq = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[0], "lq" + region))
-                salary_sector_15_uq = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[0], "uq" + region))
-                salary_sector_15_pop = getattr(salaries_aggregate.aggregated_salaries_sector[0], "pop" + region)
-                inst_prov_pc_go = getattr(salaries_aggregate.aggregated_salaries_inst[0], 'prov_pc' + region)
-            else:
-                salary_sector_15_unavail_text = unavailable_region_not_exists
-                salary_sector_15_med = None
-                salary_sector_15_lq = None
-                salary_sector_15_uq = None
-                salary_sector_15_pop = None
-                inst_prov_pc_go = None
-        else:
-            if region in ('_uk', '_e', '_s', '_w', '_ni'):
-                salary_sector_15_unavail_text = unavailable_region_not_exists
-            else:
-                salary_sector_15_unavail_text = unavailable_region_not_nation
-            salary_sector_15_med = None
-            salary_sector_15_lq = None
-            salary_sector_15_uq = None
-            salary_sector_15_pop = None
-            inst_prov_pc_go = None
-
-        if not inst_prov_pc_go:
-            inst_prov_pc_go = 0
-
-        attr = getattr(salaries_aggregate.aggregated_salaries_sector[1], "med" + region, None)
-        if attr is not None:
-            if getattr(salaries_aggregate.aggregated_salaries_sector[1], "med" + region) == "" or getattr(
-                    salaries_aggregate.aggregated_salaries_sector[1], "med" + region) is None:
-                salary_sector_3_unavail_text = unavailable_region_not_exists
-            elif region == '_ni':
-                salary_sector_3_unavail_text = unavailable_region_is_ni
-
-            med = getattr(salaries_aggregate.aggregated_salaries_sector[1], "med" + region)
-            if med is not None and med != "NA":
-                salary_sector_3_med = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[1], "med" + region))
-                salary_sector_3_lq = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[1], "lq" + region))
-                salary_sector_3_uq = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[1], "uq" + region))
-                salary_sector_3_pop = getattr(salaries_aggregate.aggregated_salaries_sector[1], "pop" + region)
-                inst_prov_pc_leo3 = getattr(salaries_aggregate.aggregated_salaries_inst[1], 'prov_pc' + region)
-            else:
-                salary_sector_3_unavail_text = unavailable_region_not_exists
-                salary_sector_3_med = None
-                salary_sector_3_lq = None
-                salary_sector_3_uq = None
-                salary_sector_3_pop = None
-                inst_prov_pc_leo3 = None
-        else:
-            if region == "_ni":
-                salary_sector_3_unavail_text = unavailable_region_is_ni
-            else:
-                salary_sector_3_unavail_text = unavailable_region_not_exists
-            salary_sector_3_med = None
-            salary_sector_3_lq = None
-            salary_sector_3_uq = None
-            salary_sector_3_pop = None
-            inst_prov_pc_leo3 = None
-
-        if (not inst_prov_pc_leo3 or inst_prov_pc_leo3 == '') and (inst_prov_pc_go != ''):
-            inst_prov_pc_leo3 = inst_prov_pc_go
-
-        attr = getattr(salaries_aggregate.aggregated_salaries_sector[2], "med" + region, None)
-        if attr is not None:
-            if getattr(salaries_aggregate.aggregated_salaries_sector[2], "med" + region) == "" or getattr(
-                    salaries_aggregate.aggregated_salaries_sector[2], "med" + region) is None:
-                salary_sector_5_unavail_text = unavailable_region_not_exists
-            elif region == '_ni':
-                salary_sector_5_unavail_text = unavailable_region_is_ni
-
-            med = getattr(salaries_aggregate.aggregated_salaries_sector[2], "med" + region)
-            if med is not None and med != "NA":
-                salary_sector_5_med = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[2], "med" + region))
-                salary_sector_5_lq = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[2], "lq" + region))
-                salary_sector_5_uq = format_thousands(
-                    getattr(salaries_aggregate.aggregated_salaries_sector[2], "uq" + region))
-                salary_sector_5_pop = getattr(salaries_aggregate.aggregated_salaries_sector[2], "pop" + region)
-                inst_prov_pc_leo5 = getattr(salaries_aggregate.aggregated_salaries_inst[2], 'prov_pc' + region)
-            else:
-                salary_sector_5_unavail_text = unavailable_region_not_exists
-                salary_sector_5_med = None
-                salary_sector_5_lq = None
-                salary_sector_5_uq = None
-                salary_sector_5_pop = None
-                inst_prov_pc_leo5 = None
-        else:
-            if region == "_ni":
-                salary_sector_5_unavail_text = unavailable_region_is_ni
-            else:
-                salary_sector_5_unavail_text = unavailable_region_not_exists
-            salary_sector_5_med = None
-            salary_sector_5_lq = None
-            salary_sector_5_uq = None
-            salary_sector_5_pop = None
-            inst_prov_pc_leo5 = None
-
-        if (not inst_prov_pc_leo5 or inst_prov_pc_leo5 == '') and (inst_prov_pc_leo3 != ''):
-            inst_prov_pc_leo5 = inst_prov_pc_leo3
-
-        resp = {
-            'typical_range_text': translations.term_for_key(key='typical_range', language=language),
-            'data_from_text': translations.term_for_key(key='Data from', language=language),
-            'respondents_text': translations.term_for_key(key='respondents', language=language),
-            'people_text': translations.term_for_key(key='people', language=language),
-            'of_those_asked_text': translations.term_for_key(key='of those asked', language=language),
-            'region_full_name': region_full_name,
-
-            'salary_sector_15_med': salary_sector_15_med,
-            'salary_sector_15_lq': salary_sector_15_lq,
-            'salary_sector_15_uq': salary_sector_15_uq,
-            'salary_sector_15_pop': salary_sector_15_pop,
-            'salary_sector_15_unavail_text': salary_sector_15_unavail_text,
-
-            'salary_sector_3_med': salary_sector_3_med,
-            'salary_sector_3_lq': salary_sector_3_lq,
-            'salary_sector_3_uq': salary_sector_3_uq,
-            'salary_sector_3_pop': salary_sector_3_pop,
-            'salary_sector_3_unavail_text': salary_sector_3_unavail_text,
-
-            'salary_sector_5_med': salary_sector_5_med,
-            'salary_sector_5_lq': salary_sector_5_lq,
-            'salary_sector_5_uq': salary_sector_5_uq,
-            'salary_sector_5_pop': salary_sector_5_pop,
-            'salary_sector_5_unavail_text': salary_sector_5_unavail_text,
-
-            'inst_prov_pc_go': inst_prov_pc_go,
-            'inst_prov_pc_leo3': inst_prov_pc_leo3,
-            'inst_prov_pc_leo5': inst_prov_pc_leo5,
-            'inst_prov_pc_delimiter_go': inst_prov_pc_delimiter_go,
-            'inst_prov_pc_delimiter_leo': inst_prov_pc_delimiter_leo,
-            'inst_prov_pc_prefix': inst_prov_pc_prefix
-        }
-        return JsonResponse(resp)
-    else:
+    if 'region' not in request.POST or not request.is_ajax():
         return JsonResponse({'retval': 'unhandled error'}),
+
+    region = request.POST['region']
+    institution_id = request.POST['institution_id']
+    course_id = request.POST['course_id']
+    kis_mode = request.POST['kis_mode']
+    subject_code = request.POST['subject_code']
+    language = request.POST['language']
+    course, error = Course.find(institution_id, course_id, kis_mode, language)
+
+    with open("./CMS/static/jsonfiles/regions.json", "r") as f:
+        regions = f.read()
+    region_full_name = "region unknown"
+    region_dict = json.loads(regions)
+    for region_elem in region_dict:
+        elem_id = region_elem['id']
+        if elem_id == region:
+            region_full_name = region_elem['name_cy'] if language == 'cy' else region_elem['name_en']
+
+            if region_full_name[:2] == "- ":
+                region_full_name = region_full_name[2:]
+            break
+
+    def format_thousands(earnings):
+        return f'{int(earnings):,}'
+
+    if language == 'cy':
+        inst_prov_pc_delimiter_go = "wedi'u cyflogi yn"
+        inst_prov_pc_delimiter_leo = "wedi'u lleoli yn"
+        inst_prov_pc_prefix = "Mae "
+    else:
+        inst_prov_pc_delimiter_go = "are employed in"
+        inst_prov_pc_delimiter_leo = "are based in"
+        inst_prov_pc_prefix = ""
+
+    salaries_aggregate = [element for element in course.salary_aggregates if element.subject_code == subject_code][
+        0]
+
+    unavail_msgs_go = salaries_aggregate.aggregated_salaries_sector[0].display_unavailable_info(language)
+    unavail_msgs_leo = salaries_aggregate.aggregated_salaries_sector[1].display_unavailable_info(language)
+    salary_sector_15_unavail_text = ""
+    salary_sector_3_unavail_text = ""
+    salary_sector_5_unavail_text = ""
+    unavailable_region_not_exists = ""
+    unavailable_region_not_nation = ""
+    unavailable_region_is_ni = ""
+
+    if 'unavailable_region_not_exists' in unavail_msgs_leo and unavail_msgs_leo[
+        'unavailable_region_not_exists'] != "":
+        unavailable_region_not_exists = unavail_msgs_leo['unavailable_region_not_exists']
+    if 'unavailable_region_not_nation' in unavail_msgs_go and unavail_msgs_go[
+        'unavailable_region_not_nation'] != "":
+        unavailable_region_not_nation = unavail_msgs_go['unavailable_region_not_nation']
+    if 'unavailable_region_is_ni' in unavail_msgs_leo and unavail_msgs_leo['unavailable_region_is_ni'] != "":
+        unavailable_region_is_ni = unavail_msgs_leo['unavailable_region_is_ni']
+
+    salary_sectors_data: dict[str, any] = {}
+    timeframes = ("15", "3", "5")
+
+    def set_unavail_texts(index_):
+        timeframe = timeframes[index_]
+        if getattr(salaries_aggregate.aggregated_salaries_sector[index_], "med" + region) == "" or getattr(
+                salaries_aggregate.aggregated_salaries_sector[index_], "med" + region) is None:
+            salary_sectors_data[f"salary_sector_{timeframe}_unavail_text"] = unavailable_region_not_exists
+        elif region not in ('_uk', '_e', '_s', '_w', '_ni') and timeframe == "15":
+            salary_sectors_data[f"salary_sector_{timeframe}_unavail_text"] = unavailable_region_not_nation
+        elif region == "_ni" and timeframe in ("3", "5"):
+            salary_sectors_data[f"salary_sector_{timeframe}_unavail_text"] = unavailable_region_is_ni
+
+    def get_statistics(index_):
+        time_ = timeframes[index_]
+        salary_sectors_data[f"salary_sector_{time_}_med"] = format_thousands(
+            getattr(salaries_aggregate.aggregated_salaries_sector[index_], "med" + region))
+        salary_sectors_data[f"salary_sector_{time_}_lq"] = format_thousands(
+            getattr(salaries_aggregate.aggregated_salaries_sector[index_], "lq" + region))
+        salary_sectors_data[f"salary_sector_{time_}_uq"] = format_thousands(
+            getattr(salaries_aggregate.aggregated_salaries_sector[index_], "uq" + region))
+        salary_sectors_data[f"salary_sector_{time_}_pop"] = getattr(
+            salaries_aggregate.aggregated_salaries_sector[index_], "pop" + region)
+
+    def set_statistics_to_none(time_):
+        salary_sectors_data[f"salary_sector_{time_}_med"] = None
+        salary_sectors_data[f"salary_sector_{time_}_uq"] = None
+        salary_sectors_data[f"salary_sector_{time_}_lq"] = None
+        salary_sectors_data[f"salary_sector_{time_}_pop"] = None
+        if time_ == "15":
+            salary_sectors_data["inst_prov_pc_go"] = None
+        elif time in ("3", "5"):
+            salary_sectors_data[f"inst_prov_pc_leo{time_}"] = None
+
+    for index in (0, 1, 2):
+        time = timeframes[index]
+
+        attr = getattr(salaries_aggregate.aggregated_salaries_sector[index], "med" + region, None)
+        if attr is not None:
+            set_unavail_texts(index)
+
+            med = getattr(salaries_aggregate.aggregated_salaries_sector[index], "med" + region, None)
+            if med is not None and med != "NA":
+
+                get_statistics(index)
+                if time == "15":
+                    salary_sectors_data["inst_prov_pc_go"] = getattr(
+                        salaries_aggregate.aggregated_salaries_inst[index], 'prov_pc' + region)
+                elif time in ("3", "5"):
+                    salary_sectors_data[f"inst_prov_pc_leo{time}"] = getattr(
+                        salaries_aggregate.aggregated_salaries_inst[index], 'prov_pc' + region)
+
+            else:
+                salary_sectors_data[f"salary_sector_{time}_unavail_text"] = unavailable_region_not_exists
+                set_statistics_to_none(time)
+
+        else:
+            if time == "15":
+                if region in ('_uk', '_e', '_s', '_w', '_ni'):
+                    salary_sectors_data[f"salary_sector_{time}_unavail_text"] = unavailable_region_not_exists
+                else:
+                    salary_sectors_data[f"salary_sector_{time}_unavail_text"] = unavailable_region_not_nation
+            elif time in ("3", "5"):
+                if region == "_ni":
+                    salary_sectors_data[f"salary_sector_{time}_unavail_text"] = unavailable_region_is_ni
+                else:
+                    salary_sectors_data[f"salary_sector_{time}_unavail_text"] = unavailable_region_not_exists
+            set_statistics_to_none(time)
+
+        if time == "15":
+            if not salary_sectors_data["inst_prov_pc_go"]:
+                salary_sectors_data["inst_prov_pc_go"] = 0
+        elif time == "3":
+            if ((not salary_sectors_data["inst_prov_pc_leo3"] or salary_sectors_data[f"inst_prov_pc_leo3"] == '')
+                    and (salary_sectors_data["inst_prov_pc_go"] != '')):
+                salary_sectors_data[f"inst_prov_pc_leo3"] = salary_sectors_data["inst_prov_pc_go"]
+        elif time == "5":
+            if ((not salary_sectors_data["inst_prov_pc_leo5"] or salary_sectors_data["inst_prov_pc_leo5"] == '')
+                    and (salary_sectors_data[f"inst_prov_pc_leo3"] != '')):
+                salary_sectors_data["inst_prov_pc_leo5"] = salary_sectors_data[f"inst_prov_pc_leo3"]
+
+    resp = {
+        'typical_range_text': translations.term_for_key(key='typical_range', language=language),
+        'data_from_text': translations.term_for_key(key='Data from', language=language),
+        'respondents_text': translations.term_for_key(key='respondents', language=language),
+        'people_text': translations.term_for_key(key='people', language=language),
+        'of_those_asked_text': translations.term_for_key(key='of those asked', language=language),
+        'region_full_name': region_full_name,
+
+        'salary_sector_15_med': salary_sectors_data["salary_sector_15_med"],
+        'salary_sector_15_lq': salary_sectors_data["salary_sector_15_lq"],
+        'salary_sector_15_uq': salary_sectors_data["salary_sector_15_uq"],
+        'salary_sector_15_pop': salary_sectors_data["salary_sector_15_pop"],
+        'salary_sector_15_unavail_text': salary_sector_15_unavail_text,
+
+        'salary_sector_3_med': salary_sectors_data["salary_sector_3_med"],
+        'salary_sector_3_lq': salary_sectors_data["salary_sector_3_lq"],
+        'salary_sector_3_uq': salary_sectors_data["salary_sector_3_uq"],
+        'salary_sector_3_pop': salary_sectors_data["salary_sector_3_pop"],
+        'salary_sector_3_unavail_text': salary_sector_3_unavail_text,
+
+        'salary_sector_5_med': salary_sectors_data["salary_sector_5_med"],
+        'salary_sector_5_lq': salary_sectors_data["salary_sector_5_lq"],
+        'salary_sector_5_uq': salary_sectors_data["salary_sector_5_uq"],
+        'salary_sector_5_pop': salary_sectors_data["salary_sector_5_pop"],
+        'salary_sector_5_unavail_text': salary_sector_5_unavail_text,
+
+        'inst_prov_pc_go': salary_sectors_data["inst_prov_pc_go"],
+        'inst_prov_pc_leo3': salary_sectors_data["inst_prov_pc_leo3"],
+        'inst_prov_pc_leo5': salary_sectors_data["inst_prov_pc_leo5"],
+        'inst_prov_pc_delimiter_go': inst_prov_pc_delimiter_go,
+        'inst_prov_pc_delimiter_leo': inst_prov_pc_delimiter_leo,
+        'inst_prov_pc_prefix': inst_prov_pc_prefix
+    }
+    return JsonResponse(resp)
 
 
 def courses_detail(request, institution_id, course_id, kis_mode, language=enums.languages.ENGLISH):

--- a/courses/views/views.py
+++ b/courses/views/views.py
@@ -60,9 +60,6 @@ def regional_earnings(request):
 
     unavail_msgs_go = salaries_aggregate.aggregated_salaries_sector[0].display_unavailable_info(language)
     unavail_msgs_leo = salaries_aggregate.aggregated_salaries_sector[1].display_unavailable_info(language)
-    salary_sector_15_unavail_text = ""
-    salary_sector_3_unavail_text = ""
-    salary_sector_5_unavail_text = ""
     unavailable_region_not_exists = ""
     unavailable_region_not_nation = ""
     unavailable_region_is_ni = ""
@@ -78,6 +75,10 @@ def regional_earnings(request):
 
     salary_sectors_data: dict[str, any] = {}
     timeframes = ("15", "3", "5")
+
+    salary_sectors_data["salary_sector_15_unavail_text"] = ""
+    salary_sectors_data["salary_sector_3_unavail_text"] = ""
+    salary_sectors_data["salary_sector_5_unavail_text"] = ""
 
     def set_unavail_texts(index_):
         timeframe = timeframes[index_]
@@ -169,19 +170,19 @@ def regional_earnings(request):
         'salary_sector_15_lq': salary_sectors_data["salary_sector_15_lq"],
         'salary_sector_15_uq': salary_sectors_data["salary_sector_15_uq"],
         'salary_sector_15_pop': salary_sectors_data["salary_sector_15_pop"],
-        'salary_sector_15_unavail_text': salary_sector_15_unavail_text,
+        'salary_sector_15_unavail_text': salary_sectors_data["salary_sector_15_unavail_text"],
 
         'salary_sector_3_med': salary_sectors_data["salary_sector_3_med"],
         'salary_sector_3_lq': salary_sectors_data["salary_sector_3_lq"],
         'salary_sector_3_uq': salary_sectors_data["salary_sector_3_uq"],
         'salary_sector_3_pop': salary_sectors_data["salary_sector_3_pop"],
-        'salary_sector_3_unavail_text': salary_sector_3_unavail_text,
+        'salary_sector_3_unavail_text': salary_sectors_data["salary_sector_3_unavail_text"],
 
         'salary_sector_5_med': salary_sectors_data["salary_sector_5_med"],
         'salary_sector_5_lq': salary_sectors_data["salary_sector_5_lq"],
         'salary_sector_5_uq': salary_sectors_data["salary_sector_5_uq"],
         'salary_sector_5_pop': salary_sectors_data["salary_sector_5_pop"],
-        'salary_sector_5_unavail_text': salary_sector_5_unavail_text,
+        'salary_sector_5_unavail_text': salary_sectors_data["salary_sector_5_unavail_text"],
 
         'inst_prov_pc_go': salary_sectors_data["inst_prov_pc_go"],
         'inst_prov_pc_leo3': salary_sectors_data["inst_prov_pc_leo3"],

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -42,7 +42,6 @@ def get_tef_status(institution):
         return institution.pub_ukprn_country_code
 
 
-
 def institution_detail(request, institution_id, language=enums.languages.ENGLISH):
     institution, error = Institution.find(institution_id, language)
     if error:
@@ -145,8 +144,8 @@ def get_tef_body_copy_context(institution, language, status, tef_context, affili
         tef_context["right_button"] = term_for_key("find_out_more_about_tef", language=language)
         tef_context["right_link"] = "https://discoveruni.gov.uk/how-do-i-choose-course/quality-and-standards/#teaching_excellence_and_student_outcomes_framework_(tef)"
 
-
     tef_context["status"] = status
+
 
 def generate_tef_context(institution, language, status):
     print("status", status)


### PR DESCRIPTION
### What

Refactored the regional_earnings function: the existing layout repeats the same block of code three times for each time frame, and contains unnecessary indentation due to the error response being part of an else block at the end of an if statement. The latter has been resolved by moving the 'unhandled error' response to the top of the function meaning it will error and exit early, removing the need to indent the rest of the code.

The main body of the function has been changed to more closely follow the DRY principle, using a for loop with three iterations instead of repeating blocks of code. The relevant time frame is determined per loop using a tuple, and retrieved data is stored in a dictionary that is dynamically updated with values as the loop iterates. Data retrieval and assignment processes have also been split into smaller functions to improve readability and further reduce repetition. The returned dictionary at the end of the function has been updated to pull from the aforementioned dictionary created during the for loop.

Also changed location separator from "," to ", " to improve the look of how location lists are displayed on each course.

### How to review

The changes can be reviewed by navigating to a course's /course-details/ page (e.g., https://discoveruni.gov.uk/course-details/10007158/1132/Full-time/) and confirming that the data under "Earnings after the course" is unchanged for every location on the dropdown menu. Note: refactor may still require more thorough testing before merging.