### PR TITLE
Fix DU course page identified as crashing

### DIFF
--- a/courses/models/utils.py
+++ b/courses/models/utils.py
@@ -42,9 +42,9 @@ def separate_unavail_reason(reason_unseparated, subject_welsh=""):
         [f"Daw'r data a ddangosir gan fyfyrwyr ar y cwrs hwn a chyrsiau Eraill mewn {subject_welsh} eraill yn ystod y ddwy flynedd flaenorol.",
          f"Daw'r data a ddangosir gan fyfyrwyr ar y cwrs hwn a chyrsiau eraill dros dwy flynedd {subject_welsh}."]
     ]
-    index_of_delimiter = reason_unseparated.find('\n\n')
 
-    if index_of_delimiter > 4:
+    if reason_unseparated and reason_unseparated.find('\n\n') > 4:
+        index_of_delimiter = reason_unseparated.find('\n\n')
         reason_heading = reason_unseparated[:index_of_delimiter]
         for replacement in WELSH_UNAVAILABLE_UPDATES:
             reason_heading = reason_heading.replace(replacement[0], replacement[1])


### PR DESCRIPTION
Ingested data appears to have no unavail message, update code to handle this scenario

### What

Issue has come up: Open University has found that one of its courses (PUBUKPRN: 10007773, KISCOURSE: Q77) is listed in DU but returns 'Internal Server Error' when try to open course page.  I've checked the dataset and core info is there so it should be displaying.  Can you check it out? [Internal server error (discoveruni.gov.uk)](https://www.discoveruni.gov.uk/course-details/10007773/Q77/Part-time/)

### How to review

Run the changes locally and visit the page and check the data is correct in the student satisfaction section
