### PR TITLE
- only wait 10 seconds for proxied content avoids long hangs on the f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,17 @@ Once a release has been signed off and deployed to production, you need to:
 - tag master with the release number at the point it was merged in.
 - delete the release branch
 
+## Performance and Reliability
+
+### Widget Proxy Timeout
+
+The `proxy_content` endpoint, used by the v2 widget and related API endpoints, includes a **10-second timeout** for external requests to the widget host (`WIDGET_HOST`). 
+
+This change ensures that:
+- **Server Resources:** Prevents application threads from hanging indefinitely if the external service is slow or unresponsive.
+- **User Experience:** Provides a deterministic failure state (502 Bad Gateway) after 10 seconds, rather than an infinite loading state.
+- **System Stability:** Protects the CMS from cascading failures during periods of external service degradation.
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/v2_widget/views.py
+++ b/v2_widget/views.py
@@ -46,7 +46,7 @@ def proxy_content(request, target_url: str, content_type="text/html"):
 
     if request.method == "GET":
         params = request.GET.dict()
-        response = requests.get(target_url, params=params, headers=headers)
+        response = requests.get(target_url, params=params, headers=headers, timeout=10)
     else:
         return HttpResponse("Method not allowed", status=405)
 


### PR DESCRIPTION
…rontend and when serving the widget.

- side affect however is it will show a 502

NB No rush to deploy. Include in next release