### PR TITLE
fix:: translations and url link

### DIFF
--- a/CMS/translations/dictionaries/general.py
+++ b/CMS/translations/dictionaries/general.py
@@ -102,8 +102,8 @@ DICT = {
         "en": "at"
     },
     "average_earnings_course_overview_1": {
-        "cy": "Enillion cyfartalog",
-        "en": "Average Earnings for"
+        "cy": "Enillion canolrifol ar gyfer",
+        "en": "Median earnings for"
     },
     "average_earnings_course_overview_2a": {
         "cy": "15 mis ar ôl y cwrs",
@@ -346,7 +346,7 @@ DICT = {
         "en": "/search-landing-page/course-finder-choose-country/"
     },
     "courses": {
-        "cy": "cwrs/cyrsiau",
+        "cy": "cwrs/cyrsiau", #TODO: Check translation
         "en": "course(s)"
     },
     "courses_added": {
@@ -1505,10 +1505,12 @@ DICT = {
     "earnings_info_box": {
         "cy": "<li>Mae marchnadoedd llafur yn newid.</li>"
               "<li>Mae cyflogau yn amrywio ar draws rhanbarthau yn y DU. </li>"
-              "<li>Mae yna lawer o ffactorau sy'n effeithio ar enillion graddedigion.</li>",
+              "<li>Mae yna lawer o ffactorau sy'n effeithio ar enillion graddedigion.</li>"
+              "<li>Sylwch mai gwerth enwol sydd i’r ffigurau enillion a roddir — maent yn dangos faint o arian parod a dalwyd i rywun yn y ffrâm amser dan sylw, heb roi cyfrif am chwyddiant.</li>",
         "en": "<li>Labour markets change </li>"
               "<li>Salaries vary across regions in the UK</li>"
               "<li>There are lots of factors that affect graduate earnings.</li>"
+              "<li>Please note that the earnings figures given are nominal — they show the amount of cash someone got paid in the stated timeframe, without accounting for inflation.</li>"
     },
 
     'graduate_perceptions_info_box': {

--- a/CMS/translations/dictionaries/statistics.py
+++ b/CMS/translations/dictionaries/statistics.py
@@ -112,8 +112,8 @@ STATISTICS = {
         "en": "Some data may be for a course and some for a subject - course data is more specific but subject data will still give an indication of students’ views. Use caution when comparing the two."
     },
     "graduate_link": {
-        "cy": "https://discoveruni.gov.uk/cy/yngl%C5%B7n-%C3%A2n-data-about-our-data-cy/#arolwg_canlyniadau_graddedigion",
-        "en": "https://www.discoveruni.gov.uk/about-our-data/#graduate_outcomes_survey"
+        "cy": "https://discoveruni.gov.uk/cy/how-choose-course-cy/rhagolygon-cyflogaeth-employment-prospects/",
+        "en": "https://discoveruni.gov.uk/how-do-i-choose-course/employment-prospects/"
     },
     "graduate_perceptions": {
         "cy": "Canfyddiadau graddedigion",


### PR DESCRIPTION
### What

- add bullet point and translation to 'earnings after the course' list.
- update 'read more about earnings' link to correct url for english and welsh endpoints.
- update Average earnings to median earnings
