### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,10 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args:
+          - --max-line-length=88
+          - --extend-ignore=E203,W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,12 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
+
+  - repo: local
     hooks:
-      - id: flake8
-        args:
-          - --max-line-length=88
-          - --extend-ignore=E203,W503
+      - id: django-tests
+        name: Django tests
+        entry: python manage.py test
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
### Tickets addressed

Adds pre-commit and a configuration for pre-commit. Performs the following actions before allowing code to be committed:
- Runs Black code linter (https://black.readthedocs.io/en/stable/index.html)
- Runs Django tests (with `python manage.py test`)

When merged, pre-commit hook should be installed with `pre-commit install`

### (Optional) steps to test

- [x] Pull this branch
- [x] Run `pip install -r requirements.txt` to install pre-commit
- [x] Run `pre-commit install` to install pre-commit hook
- [x] Make a change to a python file and attempt to commit, Black should run on all changed files
- [x] Force a test to fail and attempt to commit, the commit should fail as the tests have failed
- Do not push any test commits

### Checklist

 - [x] Changes generate no new warnings.
 - [x] I have confirmed the tests are passing (python manage.py test).
